### PR TITLE
Minor edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The ``examples`` command in the CLI module writes a series of example Phenopackets to file.
 
-```bazaar
+```bash
 mvn package
 java -jar phenotools-cli/target/phenotools-cli-0.0.1-SNAPSHOT.jar examples
 ```

--- a/phenotools-cli/pom.xml
+++ b/phenotools-cli/pom.xml
@@ -34,21 +34,7 @@
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/phenotools-cli/src/main/java/org/phenopackets/phenotools/command/ConvertCommand.java
+++ b/phenotools-cli/src/main/java/org/phenopackets/phenotools/command/ConvertCommand.java
@@ -6,6 +6,7 @@ import org.phenopackets.phenotools.converter.converters.PhenopacketConverter;
 import org.phenopackets.schema.v2.Phenopacket;
 import picocli.CommandLine.Command;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -41,8 +42,8 @@ public class ConvertCommand implements Callable<Integer> {
             return 1;
         }
         var builder = org.phenopackets.schema.v1.Phenopacket.newBuilder();
-        try {
-            JsonFormat.parser().ignoringUnknownFields().merge(Files.newBufferedReader(inPath), builder);
+        try (BufferedReader reader = Files.newBufferedReader(inPath)) {
+            JsonFormat.parser().ignoringUnknownFields().merge(reader, builder);
         } catch (IOException e) {
             System.err.println("Error! Unable to read input file, " + e.getMessage() + "\nPlease check the format of file " + inPath);
             return 1;

--- a/phenotools-cli/src/main/java/org/phenopackets/phenotools/command/ExamplesCommand.java
+++ b/phenotools-cli/src/main/java/org/phenopackets/phenotools/command/ExamplesCommand.java
@@ -20,10 +20,10 @@ import java.util.concurrent.Callable;
 public class ExamplesCommand implements Callable<Integer> {
 
     @Option(names = {"-o", "--outdir"}, description = "path to out directory (default: current directory)")
-    public String outdir = ".";
+    public Path outdir = Path.of("");
 
-    private void outputPhenopacket(String fileName, Phenopacket phenopacket) throws Exception {
-        Path outDirectory = createOutdirectoryIfNeeded(outdir);
+    private void outputPhenopacket(String fileName, Phenopacket phenopacket) {
+        Path outDirectory = createOutDirectoryIfNeeded(outdir);
         Path path = outDirectory.resolve(fileName);
         try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
             String json = JsonFormat.printer().print(phenopacket);
@@ -33,8 +33,7 @@ public class ExamplesCommand implements Callable<Integer> {
         }
     }
 
-    private Path createOutdirectoryIfNeeded(String outDir) throws Exception {
-        Path outDirectory = Path.of(outDir);
+    private Path createOutDirectoryIfNeeded(Path outDirectory) {
         if (Files.exists(outDirectory)) {
             return outDirectory;
         }
@@ -43,7 +42,7 @@ public class ExamplesCommand implements Callable<Integer> {
         } catch (IOException e) {
             // swallow
         }
-        throw new PhenotoolsRuntimeException("Could not create directory " + outDir);
+        throw new PhenotoolsRuntimeException("Could not create directory " + outDirectory.toAbsolutePath());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -76,22 +76,29 @@
     </properties>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>2.5.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>
@@ -102,64 +109,6 @@
                 <artifactId>phenopacket-schema</artifactId>
                 <version>${phenopacket-schema.version}</version>
                 <scope>compile</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.protobuf</groupId>
-                        <artifactId>protobuf-java</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-protobuf</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-yaml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.yaml</groupId>
-                        <artifactId>snakeyaml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-slf4j18-impl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-collections</groupId>
-                        <artifactId>commons-collections</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.protobuf</groupId>
-                        <artifactId>protobuf-java-util</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
- simplify POMs
  - the compiler and surefire plugins are *core plugins* and do not need to be spelled out in the parent POM.
  - plugin management section specifies plugin versions and configuration for the entire project
  - the exclusions are no-op, thus I removed them
- close the `BufferedReader` in the `convert` command
- use `Path` instead of a plain `String` in the `examples` command
- small fix in `README.md`