### PR TITLE
Update Java module names

### DIFF
--- a/phenopacket-tools-builder/src/main/java/module-info.java
+++ b/phenopacket-tools-builder/src/main/java/module-info.java
@@ -1,8 +1,6 @@
-module org.phenopacket.tools.builder {
-    // TODO - needs to be fixed after modular phenopacket schema is deployed to MC
-    requires transitive phenopacket.schema;
-
-    requires com.google.protobuf;
+module org.phenopackets.phenopackettools.builder {
+    requires transitive org.phenopackets.schema;
+    requires transitive com.google.protobuf; // TODO - investigate
 
     exports org.phenopackets.phenopackettools.builder;
     exports org.phenopackets.phenopackettools.builder.builders;

--- a/phenopacket-tools-cli/src/main/java/module-info.java
+++ b/phenopacket-tools-cli/src/main/java/module-info.java
@@ -1,9 +1,8 @@
-module org.phenopacket.tools.cli {
-    requires org.phenopacket.tools.converter;
-    requires org.phenopacket.tools.builder;
-    requires org.phenopacket.tools.validator.jsonschema;
+module org.phenopackets.phenopackettools.cli {
+    requires org.phenopackets.phenopackettools.converter;
+    requires org.phenopackets.phenopackettools.builder;
+    requires org.phenopackets.phenopackettools.validator.jsonschema;
 
-    requires com.google.protobuf;
     requires com.google.protobuf.util;
     requires com.fasterxml.jackson.databind;
     requires com.fasterxml.jackson.dataformat.yaml;

--- a/phenopacket-tools-converter/src/main/java/module-info.java
+++ b/phenopacket-tools-converter/src/main/java/module-info.java
@@ -1,8 +1,5 @@
-module org.phenopacket.tools.converter {
-    // TODO - needs to be fixed after modular phenopacket schema is deployed to MC
-    requires transitive phenopacket.schema;
-    requires com.google.protobuf;
+module org.phenopackets.phenopackettools.converter {
+    requires transitive org.phenopackets.schema;
 
-    // TODO - do we want to export the `v2` package as well?
     exports org.phenopackets.phenopackettools.converter.converters;
 }

--- a/phenopacket-tools-validator-core/src/main/java/module-info.java
+++ b/phenopacket-tools-validator-core/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module org.phenopacket.tools.validator.core {
+module org.phenopackets.phenopackettools.validator.core {
     requires org.slf4j;
 
     exports org.phenopackets.phenopackettools.validator.core;

--- a/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module org.phenopacket.tools.validator.jsonschema {
-    requires transitive org.phenopacket.tools.validator.core;
+module org.phenopackets.phenopackettools.validator.jsonschema {
+    requires transitive org.phenopackets.phenopackettools.validator.core;
 
     requires com.fasterxml.jackson.databind;
     requires json.schema.validator;

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <java.version>11</java.version>
 
         <protobuf.version>3.14.0</protobuf.version>
-        <phenopacket-schema.version>2.0.1</phenopacket-schema.version>
+        <phenopacket-schema.version>2.0.2</phenopacket-schema.version>
 
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
     </properties>


### PR DESCRIPTION
The PR contains updates of the `module-info.java` files. The module names are changed to stem from `org.phenopackets.phenopackettools`. The version of the `phenopacket-schema` is bumped to `v2.0.2`.

There is one thing I am not certain about in the `module-info.java` of the builder module. Should we require `com.google.protobuf` in a transitive way? There is already a transitive requirement for `org.phenopacket.schema`, which requires protobuf. However, the `TimestampBuilder` includes `Timestamp` in the API independently of the protobuf, so maybe the transitive requirement is appropriate here too. I'll investigate this further.