### PR TITLE
Update artifact version and java versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,14 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, macOS-latest, ubuntu-latest ]
-        jdk: [ 11 ]
+        jdk: [ 17 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 Multimodule Java library/app that contains a "streamlined builder" module, a v1 to v2 converter app, a validator API and a JSON validator. 
 
+Both library and app requires Java 17 or better to run.
 
 ## Phenopacket tools CLI
 

--- a/phenopacket-tools-builder/pom.xml
+++ b/phenopacket-tools-builder/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.phenopackets.phenopackettools</groupId>
         <artifactId>phenopacket-tools</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phenopacket-tools-builder</artifactId>

--- a/phenopacket-tools-cli/pom.xml
+++ b/phenopacket-tools-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.phenopackets.phenopackettools</groupId>
         <artifactId>phenopacket-tools</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phenopacket-tools-cli</artifactId>

--- a/phenopacket-tools-converter/pom.xml
+++ b/phenopacket-tools-converter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.phenopackets.phenopackettools</groupId>
         <artifactId>phenopacket-tools</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phenopacket-tools-converter</artifactId>

--- a/phenopacket-tools-validator-core/pom.xml
+++ b/phenopacket-tools-validator-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.phenopackets.phenopackettools</groupId>
         <artifactId>phenopacket-tools</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phenopacket-tools-validator-core</artifactId>

--- a/phenopacket-tools-validator-jsonschema/pom.xml
+++ b/phenopacket-tools-validator-jsonschema/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.phenopackets.phenopackettools</groupId>
         <artifactId>phenopacket-tools</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>0.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>phenopacket-tools-validator-jsonschema</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,13 @@
 
     <groupId>org.phenopackets.phenopackettools</groupId>
     <artifactId>phenopacket-tools</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
+
+    <prerequisites>
+        <maven>3.6.0</maven>
+    </prerequisites>
 
     <modules>
         <module>phenopacket-tools-builder</module>
@@ -24,6 +28,8 @@
         <version>2.6.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
+
+
 
     <licenses>
         <license>
@@ -101,6 +107,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>17</java.version>
 
         <protobuf.version>3.21.1</protobuf.version>
         <phenopacket-schema.version>2.0.2</phenopacket-schema.version>


### PR DESCRIPTION
The short PR sets proper artifact versions into `pom.xml`s and bumps Java to 17. I think these changes should go to `develop` right away and we should not wait until the `v0.4.0` branch is finalized.