### PR TITLE
Prepare for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,17 +61,22 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/phenopackets/phenopacket-validator.git</connection>
-        <developerConnection>scm:git:ssh://github.com:phenopackets/phenopackets/phenopacket-tools.git
-        </developerConnection>
+        <connection>scm:git:https://github.com/phenopackets/phenopacket-tools.git</connection>
+        <developerConnection>scm:git:ssh://github.com:phenopackets/phenopacket-tools.git</developerConnection>
         <url>https://github.com/phenopackets/phenopacket-tools</url>
-        <tag>HEAD</tag>
+        <tag>v${project.version}</tag>
     </scm>
 
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/phenopackets/phenopacket-tools</url>
-    </ciManagement>
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -188,10 +193,97 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-          <dependency>
-              <groupId>org.hamcrest</groupId>
-              <artifactId>hamcrest-core</artifactId>
-              <scope>test</scope>
-          </dependency>
-      </dependencies>
-  </project>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- This profile should be activated only during local install or deploying a release. -->
+            <!-- The GPG plugin is used to sign the artifacts. Note that you need to set up your GPG key first. -->
+            <!-- Activate the profile by running e.g. `./mvnw -Prelease clean deploy` -->
+            <id>release</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-source-plugin</artifactId>
+                            <version>2.2.1</version>
+                            <executions>
+                                <execution>
+                                    <id>attach-sources</id>
+                                    <goals>
+                                        <goal>jar-no-fork</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>3.3.1</version>
+                            <configuration>
+                                <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+                                <doclint>none</doclint>
+                                <quiet>true</quiet>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <id>attach-javadocs</id>
+                                    <goals>
+                                        <goal>jar</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-release-plugin</artifactId>
+                            <version>3.0.0-M5</version>
+                        </plugin>
+                        <plugin>
+                            <!-- override version of GPG plugin to use new GPG signing features -->
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-gpg-plugin</artifactId>
+                            <version>1.6</version>
+                            <executions>
+                                <execution>
+                                    <id>sign-artifacts</id>
+                                    <phase>verify</phase>
+                                    <goals>
+                                        <goal>sign</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-deploy-plugin</artifactId>
+                            <version>3.0.0-M2</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>


### PR DESCRIPTION
Prepare the library for release into Maven repo.

The PR does several things:
- adds `release` profile that includes plugins required for release, but not for ordinary build, such as javadoc generation, packaging sources, and GPG signing
- adds `distributionManagement` section for releasing SNAPSHOTs as well as release versions into Sonatype & Maven central
- removes obsolete Travis CI section

With the changes in place, the library can be released by running:

```shell
cd phenopacket-tools
./mvnw -P clean deploy
```

assuming the deployer has the appropriate setup and privileges.