### PR TITLE
Let the user adjust the output verbosity at runtime

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -70,6 +70,10 @@ In the next sections, we will run *phenopacket-tools* by using the following ali
 
   $ alias pxf="java -jar phenopacket-tools-cli-${project.version}.jar"
 
+.. note::
+  The commands report warnings and errors by default. Use `-v` to increase the verbosity and see what's
+  going on under the hood. The `-v` can be specified multiple times (e.g. `-vvv`).
+
 *examples* - generate examples of the top-level elements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/phenopacket-tools-cli/src/main/java/module-info.java
+++ b/phenopacket-tools-cli/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.phenopackets.phenopackettools.cli {
     requires commons.csv;
     requires info.picocli;
     requires org.slf4j;
+    requires logback.classic;
 
     opens org.phenopackets.phenopackettools.command to info.picocli;
     opens org.phenopackets.phenopackettools.command.validate to info.picocli;

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/BaseCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/BaseCommand.java
@@ -1,8 +1,11 @@
 package org.phenopackets.phenopackettools.command;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 import org.phenopackets.phenopackettools.Main;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,19 +16,48 @@ public abstract class BaseCommand implements Callable<Integer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseCommand.class);
 
-    protected static final String BANNER = readBanner();
-
     protected static final Properties APPLICATION_PROPERTIES = readApplicationProperties();
 
     protected static final String PHENOPACKET_TOOLS_VERSION = APPLICATION_PROPERTIES.getProperty("phenopacket-tools.version", "UNKNOWN-version");
 
-    private static String readBanner() {
-        try (InputStream is = Main.class.getResourceAsStream("banner.txt")) {
-            return is == null ? "" : new String(is.readAllBytes());
-        } catch (IOException e) {
-            LOGGER.error("Unable to read banner. Please report to the developers: {}", e.getMessage(), e);
-            return "";
+    @CommandLine.Option(names = {"-v"}, description = {"Specify multiple -v options to increase verbosity.",
+            "For example, `-v -v -v` or `-vvv`"})
+    public boolean[] verbosity = {};
+
+    @Override
+    public Integer call() {
+        // (0) Setup verbosity and print banner.
+        setupLoggingAndPrintBanner();
+
+        // (1) Run the command functionality.
+        return execute();
+    }
+
+    protected abstract Integer execute();
+
+    private void setupLoggingAndPrintBanner() {
+        Level level = parseVerbosityLevel();
+
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(level);
+
+        if (!(level.equals(Level.WARN) || level.equals(Level.ERROR)))
+            printBanner();
+    }
+
+    private Level parseVerbosityLevel() {
+        int verbosity = 0;
+        for (boolean a : this.verbosity) {
+            if (a) verbosity++;
         }
+
+        return switch (verbosity) {
+            case 0 -> Level.WARN;
+            case 1 -> Level.INFO;
+            case 2 -> Level.DEBUG;
+            case 3 -> Level.TRACE;
+            default -> Level.ALL;
+        };
     }
 
     private static Properties readApplicationProperties() {
@@ -39,8 +71,17 @@ public abstract class BaseCommand implements Callable<Integer> {
         return properties;
     }
 
-    protected static void printBanner() {
-        System.err.println(BANNER);
+    private static void printBanner() {
+        System.err.println(readBanner());
+    }
+
+    private static String readBanner() {
+        try (InputStream is = Main.class.getResourceAsStream("banner.txt")) {
+            return is == null ? "" : new String(is.readAllBytes());
+        } catch (IOException e) {
+            LOGGER.error("Unable to read banner. Please report to the developers: {}", e.getMessage(), e);
+            return "";
+        }
     }
 
 }

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/BaseIOCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/BaseIOCommand.java
@@ -27,7 +27,7 @@ public abstract class BaseIOCommand extends BaseCommand {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseIOCommand.class);
 
-    @CommandLine.ArgGroup(validate = false, heading = "Inputs:%s")
+    @CommandLine.ArgGroup(validate = false, heading = "Inputs:%n")
     public InputSection inputSection = new InputSection();
 
     public static class InputSection {

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ConvertCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ConvertCommand.java
@@ -51,10 +51,7 @@ public class ConvertCommand extends BaseIOCommand {
     }
 
     @Override
-    public Integer call() {
-        // (0) Print banner.
-        printBanner();
-
+    protected Integer execute() {
         if (!checkInputArgumentsAreOk())
             return 1;
 

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ExamplesCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ExamplesCommand.java
@@ -1,7 +1,5 @@
 package org.phenopackets.phenopackettools.command;
 
-
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -20,7 +18,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.Callable;
 
 @Command(name = "examples",
         mixinStandardHelpOptions = true,
@@ -34,21 +31,19 @@ public class ExamplesCommand extends BaseCommand {
 
 
     @Override
-    public Integer call() throws Exception {
-        printBanner();
-
-        Path phenopacketDir = createADirectoryIfDoesNotExist(output.resolve("phenopackets"));
-        Path familyDir = createADirectoryIfDoesNotExist(output.resolve("families"));
-        Path cohortDir = createADirectoryIfDoesNotExist(output.resolve("cohorts"));
-
+    protected Integer execute() {
         try {
+            Path phenopacketDir = createADirectoryIfDoesNotExist(output.resolve("phenopackets"));
+            Path familyDir = createADirectoryIfDoesNotExist(output.resolve("families"));
+            Path cohortDir = createADirectoryIfDoesNotExist(output.resolve("cohorts"));
+
             // Phenopackets
             output(new AtaxiaWithVitaminEdeficiency().getPhenopacket(), phenopacketDir, "AVED");
             output(new BethlehamMyopathy().getPhenopacket(), phenopacketDir, "bethleham-myopathy");
             output(new Holoprosencephaly5().getPhenopacket(), phenopacketDir, "holoprosencephaly5");
             output(new Marfan().getPhenopacket(), phenopacketDir, "marfan");
             output(new NemalineMyopathyPrenatal().getPhenopacket(), phenopacketDir, "nemalineMyopathy");
-            output(new Pseudoexfoliation().getPhenopacket(),  phenopacketDir,"pseudoexfoliation");
+            output(new Pseudoexfoliation().getPhenopacket(), phenopacketDir, "pseudoexfoliation");
             output(new DuchenneExon51Deletion().getPhenopacket(), phenopacketDir, "duchenne");
             output(new SquamousCellCancer().getPhenopacket(), phenopacketDir, "squamous-cell-esophageal-carcinoma");
             output(new UrothelialCancer().getPhenopacket(), phenopacketDir, "urothelial-cancer");
@@ -80,10 +75,10 @@ public class ExamplesCommand extends BaseCommand {
         String yamlName = basename + ".yml";
         outputYamlPhenopacket(phenopacket, outDir, yamlName);
         String jsonName = basename + ".json";
-        outputPhenopacket(phenopacket, outDir,jsonName);
+        outputPhenopacket(phenopacket, outDir, jsonName);
     }
 
-    private static void outputPhenopacket(Message phenopacket, Path outdir,String fileName) {
+    private static void outputPhenopacket(Message phenopacket, Path outdir, String fileName) {
         outputJsonMessage(phenopacket, outdir, fileName);
     }
 

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
@@ -49,10 +49,7 @@ public class ValidateCommand extends BaseIOCommand {
     }
 
     @Override
-    public Integer call() {
-        // (0) Print banner.
-        printBanner();
-
+    protected Integer execute() {
         // (1) Read the input v2 message(s).
         List<MessageAndPath> messages = readMessagesOrExit(PhenopacketSchemaVersion.V2);
 

--- a/phenopacket-tools-cli/src/main/resources/logback.xml
+++ b/phenopacket-tools-cli/src/main/resources/logback.xml
@@ -3,19 +3,13 @@
     <property name="pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
         <target>System.err</target>
         <encoder>
             <pattern>${pattern}</pattern>
         </encoder>
     </appender>
 
-    <logger name="org.phenopackets.phenopackettools" level="DEBUG"/>
-    <logger name="com.networknt.schema" level="INFO"/>
-
-    <root level="INFO">
+    <root>
         <appender-ref ref="STDERR" />
     </root>
 </configuration>


### PR DESCRIPTION
By default, the app reports warning and errors when it is just about to crash and burn and produces no output on STDERR for the happy path. The PR adds an option to increase the logging verbosity by providing one or more `-v` options (e.g. `-vvv` for TRACE).