### PR TITLE
Elaborate on the validation workflow

### DIFF
--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationWorkflowRunner.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationWorkflowRunner.java
@@ -16,6 +16,13 @@ import java.util.List;
  * <p>
  * Validator provides a list with {@link ValidatorInfo} that describes validations
  * done by the {@link ValidationWorkflowRunner}.
+ * <p>
+ * The validation is generally done in 2 phases, <em>syntax</em> and <em>semantic</em> phases.
+ * The <em>syntax</em> phase checks if the building blocks meet the requirements independently
+ * (e.g. all required fields are defined for a {@link org.phenopackets.schema.v2.core.Resource}).
+ * The <em>semantic</em> validation checks for presence of errors in the context of the entire top-level element
+ * (e.g. a phenopacket contains an HPO term but an HPO {@link org.phenopackets.schema.v2.core.Resource} is missing
+ * in {@link org.phenopackets.schema.v2.core.MetaData}).
  *
  * @param <T> type of the top-level element of the Phenopacket schema.
  */

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationWorkflowRunnerBuilder.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationWorkflowRunnerBuilder.java
@@ -1,0 +1,71 @@
+package org.phenopackets.phenopackettools.validator.core;
+
+import com.google.protobuf.MessageOrBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The base builder for constructing {@link ValidationWorkflowRunner}. The builder keeps track of
+ * the <em>syntax</em> validators and <em>semantic</em> validators.
+ * @param <T>
+ */
+public abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> {
+
+    protected final List<PhenopacketValidator<T>> syntaxValidators = new ArrayList<>();
+    protected final List<PhenopacketValidator<T>> semanticValidators = new ArrayList<>();
+
+    /**
+     * Add a syntax validator.
+     *
+     * @param syntaxValidator the syntax validator
+     * @return the builder
+     */
+    public ValidationWorkflowRunnerBuilder<T> addSyntaxValidator(PhenopacketValidator<T> syntaxValidator) {
+        this.syntaxValidators.add(syntaxValidator);
+        return this;
+    }
+
+    /**
+     * Add syntax validators in bulk.
+     *
+     * @param validators the syntax validators
+     * @return the builder
+     */
+    public ValidationWorkflowRunnerBuilder<T> addAllSyntaxValidators(List<PhenopacketValidator<T>> validators) {
+        // A slightly more efficient implementation comparing to the default method on the interface.
+        this.syntaxValidators.addAll(validators);
+        return this;
+    }
+
+    /**
+     * Add a semantic validator.
+     *
+     * @param semanticValidator the semantic validator
+     * @return the builder
+     */
+    public ValidationWorkflowRunnerBuilder<T> addSemanticValidator(PhenopacketValidator<T> semanticValidator) {
+        this.semanticValidators.add(semanticValidator);
+        return this;
+    }
+
+    /**
+     * Add semantic validators in bulk.
+     *
+     * @param validators the semantic validators
+     * @return the builder
+     */
+    public ValidationWorkflowRunnerBuilder<T> addAllSemanticValidators(List<PhenopacketValidator<T>> validators) {
+        // A slightly more efficient implementation comparing to the default method on the interface.
+        this.semanticValidators.addAll(validators);
+        return this;
+    }
+
+    /**
+     * Finish building of the {@link ValidationWorkflowRunner}.
+     *
+     * @return the runner
+     */
+    public abstract ValidationWorkflowRunner<T> build();
+
+}

--- a/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
@@ -1,3 +1,9 @@
+/**
+ * The module provides a {@link org.phenopackets.phenopackettools.validator.core.ValidationWorkflowRunner} implementation
+ * backed by a JSON schema validator.
+ *
+ * @see org.phenopackets.phenopackettools.validator.jsonschema.JsonSchemaValidationWorkflowRunner
+ */
 module org.phenopackets.phenopackettools.validator.jsonschema {
     requires org.phenopackets.phenopackettools.util;
     requires transitive org.phenopackets.phenopackettools.validator.core;

--- a/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/BaseValidationWorkflowRunnerBuilder.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/BaseValidationWorkflowRunnerBuilder.java
@@ -18,14 +18,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A utility class that provides {@link JsonSchemaValidationWorkflowRunner.Builder} implementations for top-level
+ * A utility class that provides {@link JsonSchemaValidationWorkflowRunnerBuilder} implementations for top-level
  * elements of Phenopacket schema.
  * <p>
  * The class exists because we do not want to expose {@link JsonSchemaValidator} to the outside world.
  */
-abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> extends JsonSchemaValidationWorkflowRunner.Builder<T> {
+abstract class BaseValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> extends JsonSchemaValidationWorkflowRunnerBuilder<T> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationWorkflowRunnerBuilder.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseValidationWorkflowRunnerBuilder.class);
 
     @Override
     public JsonSchemaValidationWorkflowRunner<T> build() {
@@ -33,6 +33,7 @@ abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> exten
         return new JsonSchemaValidationWorkflowRunner<>(getFormatConverter(),
                 getBaseRequirementsValidator(),
                 requirementValidators,
+                syntaxValidators,
                 semanticValidators);
     }
 
@@ -56,7 +57,7 @@ abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> exten
         return requirementValidators;
     }
 
-    static class PhenopacketWorkflowRunnerBuilder extends ValidationWorkflowRunnerBuilder<PhenopacketOrBuilder> {
+    static class PhenopacketWorkflowRunnerBuilder extends BaseValidationWorkflowRunnerBuilder<PhenopacketOrBuilder> {
 
         @Override
         protected PhenopacketFormatConverter<PhenopacketOrBuilder> getFormatConverter() {
@@ -69,7 +70,7 @@ abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> exten
         }
     }
 
-    static class FamilyWorkflowRunnerBuilder extends ValidationWorkflowRunnerBuilder<FamilyOrBuilder> {
+    static class FamilyWorkflowRunnerBuilder extends BaseValidationWorkflowRunnerBuilder<FamilyOrBuilder> {
         @Override
         protected PhenopacketFormatConverter<FamilyOrBuilder> getFormatConverter() {
             return PhenopacketFormatConverters.familyConverter();
@@ -82,7 +83,7 @@ abstract class ValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> exten
     }
 
 
-    static class CohortWorkflowRunnerBuilder extends ValidationWorkflowRunnerBuilder<CohortOrBuilder> {
+    static class CohortWorkflowRunnerBuilder extends BaseValidationWorkflowRunnerBuilder<CohortOrBuilder> {
         @Override
         protected PhenopacketFormatConverter<CohortOrBuilder> getFormatConverter() {
             return PhenopacketFormatConverters.cohortConverter();

--- a/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunner.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunner.java
@@ -13,9 +13,6 @@ import org.phenopackets.schema.v2.CohortOrBuilder;
 import org.phenopackets.schema.v2.FamilyOrBuilder;
 import org.phenopackets.schema.v2.PhenopacketOrBuilder;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,17 +22,18 @@ import java.util.Objects;
  * Validates if given top-level element satisfies the following criteria:
  * <ul>
  *     <li><b>data format requirements</b> - for instance if the element is a valid JSON document if JSON input is provided</li>
- *     <li><b>basic Phenopacket schema requirements</b> - the requirements described by the reference documentation.
+ *     <li><b>basic Phenopacket schema syntax requirements</b> - the requirements described by the reference documentation.
  *     Absence of a <em>required</em> field is an {@link ValidationLevel#ERROR} and absence of a recommended field is
- *     a {@link ValidationLevel#WARNING}.</li>
- *     <li><b>custom requirements</b> - requirements provided in a JSON schema document(s) provided by the user.</li>
- *     <li><b>semantic requirements</b> - requirements checked by {@link PhenopacketValidator}s provided by the user.</li>
+ *     a {@link ValidationLevel#WARNING},</li>
+ *     <li><b>custom syntax requirements</b> - requirements provided in a JSON schema document(s) provided by the user,</li>
+ *     <li><b>syntax requirements</b> - requirements checked by the provided <em>ad hoc</em> {@link PhenopacketValidator}s,</li>
+ *     <li><b>semantic requirements</b> - requirements checked by the provided {@link PhenopacketValidator}s.</li>
  * </ul>
  * <p>
- * The validation is performed in steps as outlined by the list above. Note that the data format validation must
+ * The validation is performed in the order as outlined above. Note that the data format validation must
  * pass in order for the latter steps to run.
  * <p>
- * Use one of {@link Builder}s provided via static constructors (e.g. {@link #phenopacketBuilder()}) to build
+ * Use one of {@link JsonSchemaValidationWorkflowRunnerBuilder}s provided via static constructors (e.g. {@link #phenopacketBuilder()}) to build
  * the validation workflow.
  *
  * @param <T> must be one of the three top-level elements of the Phenopacket schema:
@@ -48,40 +46,43 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
     private final PhenopacketFormatConverter<T> converter;
     private final JsonSchemaValidator baseValidator;
     private final Collection<JsonSchemaValidator> requirementValidators;
+    private final Collection<PhenopacketValidator<T>> syntaxValidators;
     private final Collection<PhenopacketValidator<T>> semanticValidators;
     private final List<ValidatorInfo> validatorInfos;
 
     /**
-     * @return a {@link Builder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
+     * @return a {@link JsonSchemaValidationWorkflowRunnerBuilder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
      * {@link PhenopacketOrBuilder}.
      */
-    public static Builder<PhenopacketOrBuilder> phenopacketBuilder() {
-        return new ValidationWorkflowRunnerBuilder.PhenopacketWorkflowRunnerBuilder();
+    public static JsonSchemaValidationWorkflowRunnerBuilder<PhenopacketOrBuilder> phenopacketBuilder() {
+        return new BaseValidationWorkflowRunnerBuilder.PhenopacketWorkflowRunnerBuilder();
     }
 
     /**
-     * @return a {@link Builder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
+     * @return a {@link JsonSchemaValidationWorkflowRunnerBuilder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
      * {@link FamilyOrBuilder}.
      */
-    public static Builder<FamilyOrBuilder> familyBuilder() {
-        return new ValidationWorkflowRunnerBuilder.FamilyWorkflowRunnerBuilder();
+    public static JsonSchemaValidationWorkflowRunnerBuilder<FamilyOrBuilder> familyBuilder() {
+        return new BaseValidationWorkflowRunnerBuilder.FamilyWorkflowRunnerBuilder();
     }
 
     /**
-     * @return a {@link Builder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
-     * {@link CohortOrBuilder}.
+     * @return a {@link JsonSchemaValidationWorkflowRunnerBuilder} for building a {@link JsonSchemaValidationWorkflowRunner} for validating
+     * {@link CohortOrBuilder}
      */
-    public static Builder<CohortOrBuilder> cohortBuilder() {
-        return new ValidationWorkflowRunnerBuilder.CohortWorkflowRunnerBuilder();
+    public static JsonSchemaValidationWorkflowRunnerBuilder<CohortOrBuilder> cohortBuilder() {
+        return new BaseValidationWorkflowRunnerBuilder.CohortWorkflowRunnerBuilder();
     }
 
     JsonSchemaValidationWorkflowRunner(PhenopacketFormatConverter<T> converter,
                                        JsonSchemaValidator baseValidator,
                                        Collection<JsonSchemaValidator> requirementValidators,
+                                       Collection<PhenopacketValidator<T>> syntaxValidators,
                                        Collection<PhenopacketValidator<T>> semanticValidators) {
         this.converter = Objects.requireNonNull(converter);
         this.baseValidator = Objects.requireNonNull(baseValidator);
         this.requirementValidators = Objects.requireNonNull(requirementValidators);
+        this.syntaxValidators = Objects.requireNonNull(syntaxValidators);
         this.semanticValidators = Objects.requireNonNull(semanticValidators);
         this.validatorInfos = summarizeValidatorInfos(baseValidator, requirementValidators, semanticValidators);
     }
@@ -134,6 +135,12 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
         }
 
         try {
+            validateSyntax(json, builder);
+        } catch (ConversionException e) {
+            return wrapUpValidation(e, builder);
+        }
+
+        try {
             validateSemantic(json, builder);
         } catch (ConversionException e) {
             return wrapUpValidation(e, builder);
@@ -154,6 +161,8 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
             // We must not proceed with semantic validation with item that does not meet the requirements.
             return wrapUpValidation(e, builder);
         }
+
+        validateSyntax(item, builder);
 
         // No conversion necessary, hence no need to guard against the `ConversionException`.
         validateSemantic(item, builder);
@@ -176,7 +185,7 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
     /**
      * Validate requirements using {@link #baseValidator} and all {@link #requirementValidators}.
      *
-     * @throws ConversionException if {@code json} cannot be mapped into {@link JsonNode}.
+     * @throws ConversionException if {@code json} cannot be mapped into {@link JsonNode}
      */
     private void validateRequirements(String json, ValidationResults.Builder builder) throws ConversionException {
         JsonNode jsonNode;
@@ -194,10 +203,22 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
         }
     }
 
+    private void validateSyntax(String item, ValidationResults.Builder builder) throws ConversionException {
+        T component = converter.toItem(item);
+
+        validateSyntax(component, builder);
+    }
+
+    private void validateSyntax(T component, ValidationResults.Builder builder) {
+        for (PhenopacketValidator<T> validator : syntaxValidators) {
+            builder.addResults(validator.validatorInfo(), validator.validate(component));
+        }
+    }
+
     /**
      * Validate semantic requirements using {@link #semanticValidators}.
      *
-     * @throws ConversionException if {@code item} cannot be mapped into {@link T}.
+     * @throws ConversionException if {@code item} cannot be mapped into {@link T}
      */
     private void validateSemantic(String item, ValidationResults.Builder builder) throws ConversionException {
         T component = converter.toItem(item);
@@ -217,58 +238,6 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
     private static ValidationResults wrapUpValidation(ConversionException e, ValidationResults.Builder builder) {
         return builder.addResult(e.validatorInfo(), e)
                 .build();
-    }
-
-    /**
-     * A builder for {@link JsonSchemaValidationWorkflowRunner}.
-     * <p>
-     * Build the {@link JsonSchemaValidationWorkflowRunner} by providing JSON schema documents
-     * either as {@link Path} or {@link URL}s, and {@link PhenopacketValidator}s for performing semantic validation.
-     *
-     * @param <T> one of top-level elements of the Phenopacket schema.
-     */
-    public static abstract class Builder<T extends MessageOrBuilder> {
-
-        protected final List<URL> jsonSchemaUrls = new ArrayList<>();
-        protected final List<PhenopacketValidator<T>> semanticValidators = new ArrayList<>();
-
-        protected Builder() {
-            // private no-op
-        }
-
-        public Builder<T> addJsonSchema(Path path) throws MalformedURLException {
-            return addJsonSchema(path.toUri().toURL());
-        }
-
-        public Builder<T> addJsonSchema(URL url) {
-            jsonSchemaUrls.add(url);
-            return this;
-        }
-
-        public Builder<T> addAllJsonSchemaPaths(List<Path> paths) throws MalformedURLException {
-            for (Path path : paths) {
-                jsonSchemaUrls.add(path.toUri().toURL());
-            }
-            return this;
-        }
-
-        public Builder<T> addAllJsonSchemaUrls(List<URL> urls) {
-            jsonSchemaUrls.addAll(urls);
-            return this;
-        }
-
-        public Builder<T> addSemanticValidator(PhenopacketValidator<T> semanticValidator) {
-            this.semanticValidators.add(semanticValidator);
-            return this;
-        }
-
-        public Builder<T> addAllSemanticValidators(List<PhenopacketValidator<T>> semanticValidators) {
-            this.semanticValidators.addAll(semanticValidators);
-            return this;
-        }
-
-        public abstract JsonSchemaValidationWorkflowRunner<T> build();
-
     }
 
 }

--- a/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunnerBuilder.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunnerBuilder.java
@@ -1,0 +1,86 @@
+package org.phenopackets.phenopackettools.validator.jsonschema;
+
+import com.google.protobuf.MessageOrBuilder;
+import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
+import org.phenopackets.phenopackettools.validator.core.ValidationWorkflowRunnerBuilder;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder for {@link JsonSchemaValidationWorkflowRunner}.
+ * <p>
+ * Build the {@link JsonSchemaValidationWorkflowRunner} by providing JSON schema documents
+ * either as {@link Path} or {@link URL}s, and {@link PhenopacketValidator}s for performing semantic validation.
+ *
+ * @param <T> one of top-level elements of the Phenopacket schema.
+ */
+public abstract class JsonSchemaValidationWorkflowRunnerBuilder<T extends MessageOrBuilder> extends ValidationWorkflowRunnerBuilder<T> {
+
+    protected final List<URL> jsonSchemaUrls = new ArrayList<>();
+
+    protected JsonSchemaValidationWorkflowRunnerBuilder() {
+        // private no-op
+    }
+
+    /**
+     * Register a JSON schema present at a given {@code path} to be used as a syntax validator. The {@code path}
+     * will be interpreted as a {@link URL}.
+     *
+     * @param path path to the JSON schema document
+     * @return the builder
+     * @throws MalformedURLException if the {@code path} cannot be converted to a well-formatted {@link URL}
+     */
+    public JsonSchemaValidationWorkflowRunnerBuilder<T> addJsonSchema(Path path) throws MalformedURLException {
+        return addJsonSchema(path.toUri().toURL());
+    }
+
+    /**
+     * Register a JSON schema present at a given {@code url} to be used as a syntax validator.
+     *
+     * @param url url to the JSON schema document
+     * @return the builder
+     */
+    public JsonSchemaValidationWorkflowRunnerBuilder<T> addJsonSchema(URL url) {
+        jsonSchemaUrls.add(url);
+        return this;
+    }
+
+    /**
+     * Add JSON schemas in bulk.
+     *
+     * @param paths an iterable of paths pointing to JSON schema documents
+     * @return the builder
+     * @see JsonSchemaValidationWorkflowRunnerBuilder#addJsonSchema(Path)
+     */
+    public JsonSchemaValidationWorkflowRunnerBuilder<T> addAllJsonSchemaPaths(Iterable<Path> paths) throws MalformedURLException {
+        for (Path path : paths) {
+            jsonSchemaUrls.add(path.toUri().toURL());
+        }
+        return this;
+    }
+
+    /**
+     * Add JSON schemas in bulk.
+     *
+     * @param urls an iterable of urls pointing to JSON schema documents
+     * @return the builder
+     * @see JsonSchemaValidationWorkflowRunnerBuilder#addJsonSchema(URL)
+     */
+    public JsonSchemaValidationWorkflowRunnerBuilder<T> addAllJsonSchemaUrls(List<URL> urls) {
+        jsonSchemaUrls.addAll(urls);
+        return this;
+    }
+
+    /**
+     * Finish building the {@link JsonSchemaValidationWorkflowRunner}.
+     *
+     * @return the runner
+     */
+    @Override
+    public abstract JsonSchemaValidationWorkflowRunner<T> build();
+
+}


### PR DESCRIPTION
The phenopacket validation workflow consist of 2 steps: syntax step and semantic step.

The *syntax* step  checks if the building blocks meet the requirements independently (e.g. all required fields are defined for a `Resource`).

The *semantic* step checks for presence of errors in the context of the entire top-level element of the Phenopacket schema (e.g. a phenopacket contains an HPO term but a `Resource` for HPO is missing in `MetaData`).

The PR adds `ValidationWorkflowRunnerBuilder`, an abstract class to simplify `ValidationWorkflowRunner` building process.