### PR TITLE
Implement ancestry validation of HPO terms.

### DIFF
--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
@@ -143,15 +143,15 @@ public class ValidateCommand extends BaseIOCommand {
             // This method requires an appropriate combination of `T` and `element`, as described in Javadoc.
             // We suppress warning and perform an unchecked cast here, assuming `T` and `element` are appropriate.
             // The app will crash and burn if this is not the case.
-            PhenopacketValidator<T> validator = switch (inputSection.element) {
+            PhenopacketValidator<T> primary = switch (inputSection.element) {
                 case PHENOPACKET -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.phenopacketHpoPhenotypeValidator(hpo);
+                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.phenopacketHpoPhenotypeValidator(hpo);
                 case FAMILY -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.familyHpoPhenotypeValidator(hpo);
+                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.familyHpoPhenotypeValidator(hpo);
                 case COHORT -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.cohortHpoPhenotypeValidator(hpo);
+                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.cohortHpoPhenotypeValidator(hpo);
             };
-            validators.add(validator);
+            validators.add(primary);
         }
 
         LOGGER.debug("Configured {} semantic validator(s)", validators.size());

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/command/ValidateCommand.java
@@ -143,15 +143,26 @@ public class ValidateCommand extends BaseIOCommand {
             // This method requires an appropriate combination of `T` and `element`, as described in Javadoc.
             // We suppress warning and perform an unchecked cast here, assuming `T` and `element` are appropriate.
             // The app will crash and burn if this is not the case.
-            PhenopacketValidator<T> primary = switch (inputSection.element) {
-                case PHENOPACKET -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.phenopacketHpoPhenotypeValidator(hpo);
-                case FAMILY -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.familyHpoPhenotypeValidator(hpo);
-                case COHORT -> //noinspection unchecked
-                        (PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.cohortHpoPhenotypeValidator(hpo);
+            switch (inputSection.element) {
+                case PHENOPACKET -> {
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.phenopacketHpoPhenotypeValidator(hpo));
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Ancestry.phenopacketHpoAncestryValidator(hpo));
+                }
+                case FAMILY -> {
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.familyHpoPhenotypeValidator(hpo));
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Ancestry.familyHpoAncestryValidator(hpo));
+                }
+                case COHORT -> {
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Primary.cohortHpoPhenotypeValidator(hpo));
+                    //noinspection unchecked
+                    validators.add((PhenopacketValidator<T>) HpoPhenotypeValidators.Ancestry.cohortHpoAncestryValidator(hpo));
+                }
             };
-            validators.add(primary);
         }
 
         LOGGER.debug("Configured {} semantic validator(s)", validators.size());

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
@@ -2,6 +2,12 @@ package org.phenopackets.phenopackettools.validator.core.phenotype;
 
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.CohortHpoAncestryValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.FamilyHpoAncestryValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.PhenopacketHpoAncestryValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.primary.CohortHpoPhenotypeValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.primary.FamilyHpoPhenotypeValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.primary.PhenopacketHpoPhenotypeValidator;
 import org.phenopackets.schema.v2.*;
 
 /**
@@ -17,27 +23,117 @@ public class HpoPhenotypeValidators {
      * Get {@link PhenopacketValidator} to validate {@link Phenopacket} using provided {@link Ontology}.
      *
      * @param hpo HPO ontology
+     * @deprecated use {@link Primary#phenopacketHpoPhenotypeValidator(Ontology)} instead
      */
+    // TODO - remove prior v1
+    @Deprecated(forRemoval = true)
     public static PhenopacketValidator<PhenopacketOrBuilder> phenopacketHpoPhenotypeValidator(Ontology hpo) {
-        return new PhenopacketHpoPhenotypeValidator(hpo);
+        return Primary.phenopacketHpoPhenotypeValidator(hpo);
     }
 
     /**
-     * Get {@link PhenopacketValidator} to validate {@link Family} using provided {@link Ontology}.
+     * Get {@link PhenopacketValidator} for validate {@link Family} using provided {@link Ontology}.
      *
      * @param hpo HPO ontology
+     * @deprecated use {@link Primary#familyHpoPhenotypeValidator(Ontology)} instead
      */
+    // TODO - remove prior v1
+    @Deprecated(forRemoval = true)
     public static PhenopacketValidator<FamilyOrBuilder> familyHpoPhenotypeValidator(Ontology hpo) {
-        return new FamilyHpoPhenotypeValidator(hpo);
+        return Primary.familyHpoPhenotypeValidator(hpo);
     }
 
     /**
-     * Get {@link PhenopacketValidator} to validate {@link Cohort} using provided {@link Ontology}.
+     * Get {@link PhenopacketValidator} for performing primary validation {@link Cohort} using provided {@link Ontology},
+     * as described in {@link org.phenopackets.phenopackettools.validator.core.phenotype.primary.AbstractHpoPhenotypeValidator}.
      *
      * @param hpo HPO ontology
+     * @deprecated use {@link Primary#cohortHpoPhenotypeValidator(Ontology)} instead
      */
+    // TODO - remove prior v1
+    @Deprecated(forRemoval = true)
     public static PhenopacketValidator<CohortOrBuilder> cohortHpoPhenotypeValidator(Ontology hpo) {
-        return new CohortHpoPhenotypeValidator(hpo);
+        return Primary.cohortHpoPhenotypeValidator(hpo);
+    }
+
+    /**
+     * A static factory class for providing {@link org.phenopackets.phenopackettools.validator.core.PhenopacketValidator}s
+     * that check if HPO terms of the Phenopacket schema elements are present in
+     * a given {@link org.monarchinitiative.phenol.ontology.data.Ontology} and if the terms are non-obsolete.
+     */
+    public static class Primary {
+        /**
+         * Get {@link PhenopacketValidator} to validate {@link Phenopacket} using provided {@link Ontology}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<PhenopacketOrBuilder> phenopacketHpoPhenotypeValidator(Ontology hpo) {
+            return new PhenopacketHpoPhenotypeValidator(hpo);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} for validate {@link Family} using provided {@link Ontology}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<FamilyOrBuilder> familyHpoPhenotypeValidator(Ontology hpo) {
+            return new FamilyHpoPhenotypeValidator(hpo);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} for performing primary validation {@link Cohort} using provided {@link Ontology},
+         * as described in {@link org.phenopackets.phenopackettools.validator.core.phenotype.primary.AbstractHpoPhenotypeValidator}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<CohortOrBuilder> cohortHpoPhenotypeValidator(Ontology hpo) {
+            return new CohortHpoPhenotypeValidator(hpo);
+        }
+    }
+
+    /**
+     * A static factory class for providing validators for pointing out violations of the annotation propagation rule.
+     * <p>
+     * The validator checks observed and excluded phenotype terms. The observed terms are checked for a presence of
+     * an observed or an excluded ancestor, and a presence of such ancestor is pointed out as an error.
+     * For instance, Abnormality of finger or <em>"NOT"</em> Abnormality of finger must not be present
+     * in a patient annotated by Arachnodactyly. The <em>most specific</em> term (Arachnodactyly) must be used.
+     * <p>
+     * For the excluded terms, the validator checks for presence of an excluded children. Here, the least specific term
+     * must be used. For instance, <em>"NOT"</em> Arachnodactyly must not be present in a patient annotated
+     * with <em>"NOT"</em> Abnormality of finger. Only the <em>"NOT"</em> Abnormality of finger must be used.
+     */
+    public static class Ancestry {
+
+        private Ancestry() {
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate ancestry {@link Phenopacket} using provided {@link Ontology}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<PhenopacketOrBuilder> phenopacketHpoAncestryValidator(Ontology hpo) {
+            return new PhenopacketHpoAncestryValidator(hpo);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate ancestry {@link Family} using provided {@link Ontology}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<FamilyOrBuilder> familyHpoAncestryValidator(Ontology hpo) {
+            return new FamilyHpoAncestryValidator(hpo);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate ancestry {@link Cohort} using provided {@link Ontology}.
+         *
+         * @param hpo HPO ontology
+         */
+        public static PhenopacketValidator<CohortOrBuilder> cohortHpoAncestryValidator(Ontology hpo) {
+            return new CohortHpoAncestryValidator(hpo);
+        }
     }
 
 }

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/AbstractHpoAncestryValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/AbstractHpoAncestryValidator.java
@@ -1,0 +1,143 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.ancestry;
+
+import com.google.protobuf.MessageOrBuilder;
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.Term;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.phenopackettools.validator.core.ValidationResult;
+import org.phenopackets.phenopackettools.validator.core.ValidatorInfo;
+import org.phenopackets.phenopackettools.validator.core.phenotype.base.BaseHpoValidator;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A class for pointing out violations of the annotation propagation rule.
+ * <p>
+ * The validator checks observed and excluded phenotype terms. The observed terms are checked for a presence of
+ * an observed or an excluded ancestor, and a presence of such ancestor is pointed out as an error.
+ * For instance, Abnormality of finger or <em>"NOT"</em> Abnormality of finger must not be present
+ * in a patient annotated by Arachnodactyly. The <em>most specific</em> term (Arachnodactyly) must be used.
+ * <p>
+ * For the excluded terms, the validator checks for presence of an excluded children. Here, the least specific term
+ * must be used. For instance, <em>"NOT"</em> Arachnodactyly must not be present in a patient annotated
+ * with <em>"NOT"</em> Abnormality of finger. Only the <em>"NOT"</em> Abnormality of finger must be used.
+ */
+public abstract class AbstractHpoAncestryValidator<T extends MessageOrBuilder> extends BaseHpoValidator<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractHpoAncestryValidator.class);
+
+    private static final ValidatorInfo VALIDATOR_INFO = ValidatorInfo.of(
+            "HpoAncestryValidator",
+            "HPO ancestry phenotypic feature validator",
+            "Validate that phenopacket does not contain an HPO term and its ancestor based on the provided HPO");
+    private static final String APR_VIOLATION = "Violation of the annotation propagation rule";
+    private static final String UNKNOWN = "UNKNOWN_NAME";
+
+    AbstractHpoAncestryValidator(Ontology hpo) {
+        super(hpo);
+    }
+
+    @Override
+    public ValidatorInfo validatorInfo() {
+        return VALIDATOR_INFO;
+    }
+
+    @Override
+    public List<ValidationResult> validate(T component) {
+        return extractPhenopackets(component)
+                .flatMap(pp -> validatePhenopacketPhenotypicFeatures(pp.getId(), pp.getPhenotypicFeaturesList()))
+                .toList();
+    }
+
+    protected abstract Stream<? extends PhenopacketOrBuilder> extractPhenopackets(T message);
+
+    private Stream<ValidationResult> validatePhenopacketPhenotypicFeatures(String id, List<PhenotypicFeature> phenotypicFeatures) {
+        Map<Boolean, Set<TermId>> featuresByExclusion = phenotypicFeatures.stream()
+                .map(toMaybeObservedTermId())
+                .flatMap(Optional::stream)
+                // Use `partitioningBy` instead of `groupingBy` to ensure the map contains keys
+                // for both `true` and `false`. Then extract `TermId` and collect in a `Set`.
+                .collect(Collectors.partitioningBy(MaybeExcludedTermId::excluded,
+                        Collectors.mapping(MaybeExcludedTermId::termId, Collectors.toSet())));
+
+
+        Stream.Builder<ValidationResult> results = Stream.builder();
+
+        // Check that the component does not contain both observed term and its ancestor.
+        Set<? extends TermId> allObserved = featuresByExclusion.get(false);
+        Set<? extends TermId> allExcluded = featuresByExclusion.get(true);
+        for (TermId observed : allObserved) {
+            for (TermId ancestor : OntologyAlgorithm.getAncestorTerms(hpo, observed, false)) {
+                if (allObserved.contains(ancestor))
+                    results.add(constructResultForAnObservedTerm(id, observed, ancestor, false));
+                if (allExcluded.contains(ancestor))
+                    results.add(constructResultForAnObservedTerm(id, observed, ancestor, true));
+            }
+        }
+
+        // Check that the component does not have negated descendant
+        for (TermId excluded : allExcluded) {
+            for (TermId child : OntologyAlgorithm.getDescendents(hpo, excluded)) {
+                if (child.equals(excluded))
+                    // skip the parent term
+                    continue;
+                if (allExcluded.contains(child))
+                    results.add(constructResultForAnExcludedTerm(id, excluded, child));
+            }
+        }
+
+        return results.build();
+    }
+
+    private static Function<PhenotypicFeature, Optional<MaybeExcludedTermId>> toMaybeObservedTermId() {
+        return pf -> {
+            TermId termId;
+            try {
+                termId = TermId.of(pf.getType().getId());
+            } catch (PhenolRuntimeException e) {
+                LOGGER.warn("Skipping ancestry validation of malformed term ID {}", pf.getType().getId());
+                return Optional.empty();
+            }
+            return Optional.of(new MaybeExcludedTermId(termId, pf.getExcluded()));
+        };
+    }
+
+    private ValidationResult constructResultForAnObservedTerm(String id, TermId observedId, TermId ancestorId, boolean ancestorIsExcluded) {
+        Term observedTerm = hpo.getTermMap().get(observedId);
+        String observedTermName = observedTerm == null ? UNKNOWN : observedTerm.getName();
+        Term ancestorTerm = hpo.getTermMap().get(ancestorId);
+        String ancestorTermName = ancestorTerm == null ? UNKNOWN : ancestorTerm.getName();
+        String message;
+        if (ancestorIsExcluded)
+            message = "Phenotypic features of %s must not contain both an observed term (%s, %s) and an excluded ancestor (%s, %s)".formatted(
+                    id, observedTermName, observedId.getValue(), ancestorTermName, ancestorId.getValue());
+        else
+            message = "Phenotypic features of %s must not contain both an observed term (%s, %s) and an observed ancestor (%s, %s)".formatted(
+                id, observedTermName, observedId.getValue(), ancestorTermName, ancestorId.getValue());
+
+        return ValidationResult.error(VALIDATOR_INFO, APR_VIOLATION, message);
+    }
+
+    private ValidationResult constructResultForAnExcludedTerm(String id, TermId excluded, TermId child) {
+        Term excludedTerm = hpo.getTermMap().get(excluded);
+        String excludedTermName = excludedTerm == null ? UNKNOWN : excludedTerm.getName();
+        Term childTerm = hpo.getTermMap().get(child);
+        String childTermName = childTerm == null ? UNKNOWN : childTerm.getName();
+        String message = "Phenotypic features of %s must not contain both an excluded term (%s, %s) and an excluded child (%s, %s)".formatted(
+                id, excludedTermName, excluded.getValue(), childTermName, child.getValue());
+
+        return ValidationResult.error(VALIDATOR_INFO, APR_VIOLATION, message);
+    }
+
+    private record MaybeExcludedTermId(TermId termId, boolean excluded) {
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/CohortHpoAncestryValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/CohortHpoAncestryValidator.java
@@ -1,0 +1,19 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.ancestry;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.schema.v2.CohortOrBuilder;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.stream.Stream;
+
+public class CohortHpoAncestryValidator extends AbstractHpoAncestryValidator<CohortOrBuilder> {
+
+    public CohortHpoAncestryValidator(Ontology hpo) {
+        super(hpo);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> extractPhenopackets(CohortOrBuilder message) {
+        return message.getMembersList().stream();
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/FamilyHpoAncestryValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/FamilyHpoAncestryValidator.java
@@ -1,0 +1,26 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.ancestry;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.schema.v2.FamilyOrBuilder;
+import org.phenopackets.schema.v2.Phenopacket;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.stream.Stream;
+
+public class FamilyHpoAncestryValidator extends AbstractHpoAncestryValidator<FamilyOrBuilder> {
+
+    public FamilyHpoAncestryValidator(Ontology hpo) {
+        super(hpo);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> extractPhenopackets(FamilyOrBuilder message) {
+        Stream.Builder<PhenopacketOrBuilder> builder = Stream.builder();
+        builder.accept(message.getProband());
+
+        for (Phenopacket relative : message.getRelativesList())
+            builder.add(relative);
+
+        return builder.build();
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/PhenopacketHpoAncestryValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/PhenopacketHpoAncestryValidator.java
@@ -1,0 +1,19 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.ancestry;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.stream.Stream;
+
+public class PhenopacketHpoAncestryValidator extends AbstractHpoAncestryValidator<PhenopacketOrBuilder> {
+
+    public PhenopacketHpoAncestryValidator(Ontology hpo) {
+        super(hpo);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> extractPhenopackets(PhenopacketOrBuilder message) {
+        return Stream.of(message);
+    }
+
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/package-info.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/ancestry/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * The package contains validators that point out violations of the annotation propagation rule.
+ *
+ * @see org.phenopackets.phenopackettools.validator.core.phenotype.HpoPhenotypeValidators.Ancestry
+ */
+package org.phenopackets.phenopackettools.validator.core.phenotype.ancestry;

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/BaseHpoValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/BaseHpoValidator.java
@@ -1,0 +1,19 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.base;
+
+import com.google.protobuf.MessageOrBuilder;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
+
+import java.util.Objects;
+
+public abstract class BaseHpoValidator<T extends MessageOrBuilder> implements PhenopacketValidator<T> {
+
+    protected final Ontology hpo;
+    protected final String hpoVersion;
+
+    protected BaseHpoValidator(Ontology hpo) {
+        this.hpo = Objects.requireNonNull(hpo);
+        // TODO - can be replaced by this.hpo.version() in the most recent phenol versions.
+        this.hpoVersion = this.hpo.getMetaInfo().getOrDefault("data-version", "HPO");
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/package-info.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Shared bits of all {@link org.phenopackets.phenopackettools.validator.core.PhenopacketValidator}s
+ * that use HPO {@link org.monarchinitiative.phenol.ontology.data.Ontology} in validation.
+ */
+package org.phenopackets.phenopackettools.validator.core.phenotype.base;

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/CohortHpoPhenotypeValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/CohortHpoPhenotypeValidator.java
@@ -1,4 +1,4 @@
-package org.phenopackets.phenopackettools.validator.core.phenotype;
+package org.phenopackets.phenopackettools.validator.core.phenotype.primary;
 
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.phenopackets.phenopackettools.validator.core.ValidationResult;
@@ -10,9 +10,9 @@ import org.phenopackets.schema.v2.core.PhenotypicFeature;
 import java.util.ArrayList;
 import java.util.List;
 
-class CohortHpoPhenotypeValidator extends BaseHpoPhenotypeValidator<CohortOrBuilder> {
+public class CohortHpoPhenotypeValidator extends AbstractHpoPhenotypeValidator<CohortOrBuilder> {
 
-    CohortHpoPhenotypeValidator(Ontology hpo) {
+    public CohortHpoPhenotypeValidator(Ontology hpo) {
         super(hpo);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/FamilyHpoPhenotypeValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/FamilyHpoPhenotypeValidator.java
@@ -1,4 +1,4 @@
-package org.phenopackets.phenopackettools.validator.core.phenotype;
+package org.phenopackets.phenopackettools.validator.core.phenotype.primary;
 
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.phenopackets.phenopackettools.validator.core.ValidationResult;
@@ -10,9 +10,9 @@ import org.phenopackets.schema.v2.core.PhenotypicFeature;
 import java.util.ArrayList;
 import java.util.List;
 
-class FamilyHpoPhenotypeValidator extends BaseHpoPhenotypeValidator<FamilyOrBuilder> {
+public class FamilyHpoPhenotypeValidator extends AbstractHpoPhenotypeValidator<FamilyOrBuilder> {
 
-    FamilyHpoPhenotypeValidator(Ontology hpo) {
+    public FamilyHpoPhenotypeValidator(Ontology hpo) {
         super(hpo);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/PhenopacketHpoPhenotypeValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/PhenopacketHpoPhenotypeValidator.java
@@ -1,4 +1,4 @@
-package org.phenopackets.phenopackettools.validator.core.phenotype;
+package org.phenopackets.phenopackettools.validator.core.phenotype.primary;
 
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.phenopackets.phenopackettools.validator.core.ValidationResult;
@@ -9,9 +9,9 @@ import org.phenopackets.schema.v2.core.PhenotypicFeature;
 import java.util.ArrayList;
 import java.util.List;
 
-class PhenopacketHpoPhenotypeValidator extends BaseHpoPhenotypeValidator<PhenopacketOrBuilder> {
+public class PhenopacketHpoPhenotypeValidator extends AbstractHpoPhenotypeValidator<PhenopacketOrBuilder> {
 
-    PhenopacketHpoPhenotypeValidator(Ontology hpo) {
+    public PhenopacketHpoPhenotypeValidator(Ontology hpo) {
         super(hpo);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/package-info.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/primary/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * The package of {@link org.phenopackets.phenopackettools.validator.core.PhenopacketValidator}s that perform
+ * <em>primary</em> validation of HPO terms.
+ *
+ * @see org.phenopackets.phenopackettools.validator.core.phenotype.HpoPhenotypeValidators.Primary
+ */
+package org.phenopackets.phenopackettools.validator.core.phenotype.primary;

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/AncestryHpoValidatorTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/AncestryHpoValidatorTest.java
@@ -1,0 +1,118 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
+import org.phenopackets.phenopackettools.validator.core.TestData;
+import org.phenopackets.phenopackettools.validator.core.ValidationLevel;
+import org.phenopackets.phenopackettools.validator.core.ValidationResult;
+import org.phenopackets.schema.v2.Phenopacket;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+import org.phenopackets.schema.v2.core.OntologyClass;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class AncestryHpoValidatorTest {
+
+    private static final Ontology HPO = TestData.HPO;
+
+    @Nested
+    public class PhenopacketTest {
+
+        private PhenopacketValidator<PhenopacketOrBuilder> validator;
+
+        @BeforeEach
+        public void setUp() {
+            validator = HpoPhenotypeValidators.Ancestry.phenopacketHpoAncestryValidator(HPO);
+        }
+
+        @Test
+        public void testValidInput() {
+            // Has some Abnormality of finger but no Arachnodactyly.
+            Phenopacket pp = createPhenopacket(
+                    createPhenotypicFeature("HP:0001167", "Abnormality of finger", false),
+                    createPhenotypicFeature("HP:0001166", "Arachnodactyly", true)
+            ).build();
+
+            List<ValidationResult> results = validator.validate(pp);
+
+            assertThat(results, is(empty()));
+        }
+
+        @Test
+        public void testFailsIfTermAndAncestorIsObserved() {
+            // Has some Abnormality of finger and Arachnodactyly. Only Arachnodactyly should be present.
+            Phenopacket pp = createPhenopacket(
+                    createPhenotypicFeature("HP:0001167", "Abnormality of finger", false),
+                    createPhenotypicFeature("HP:0001166", "Arachnodactyly", false)
+            ).build();
+
+            List<ValidationResult> results = validator.validate(pp);
+
+            assertThat(results, hasSize(1));
+            ValidationResult result = results.get(0);
+            assertThat(result.validatorInfo(), equalTo(validator.validatorInfo()));
+            assertThat(result.level(), equalTo(ValidationLevel.ERROR));
+            assertThat(result.category(), equalTo("Violation of the annotation propagation rule"));
+            assertThat(result.message(), equalTo("Phenotypic features of example-phenopacket must not contain both an observed term (Arachnodactyly, HP:0001166) and an observed ancestor (Abnormality of finger, HP:0001167)"));
+        }
+
+        @Test
+        public void testFailsIfTermAndAncestorIsExcluded() {
+            // Has neither Abnormality of finger nor Arachnodactyly. Only Abnormality of finger should be present.
+            Phenopacket pp = createPhenopacket(
+                    createPhenotypicFeature("HP:0001167", "Abnormality of finger", true),
+                    createPhenotypicFeature("HP:0001166", "Arachnodactyly", true)
+            ).build();
+
+            List<ValidationResult> results = validator.validate(pp);
+
+            assertThat(results, hasSize(1));
+            ValidationResult result = results.get(0);
+            assertThat(result.level(), equalTo(ValidationLevel.ERROR));
+            assertThat(result.category(), equalTo("Violation of the annotation propagation rule"));
+            assertThat(result.message(), equalTo("Phenotypic features of example-phenopacket must not contain both an excluded term (Abnormality of finger, HP:0001167) and an excluded child (Arachnodactyly, HP:0001166)"));
+        }
+
+        @Test
+        public void testFailsIfTermIsPresentAndAncestorIsExcluded() {
+            // Has neither Abnormality of finger nor Arachnodactyly. Only Abnormality of finger should be present.
+            Phenopacket pp = createPhenopacket(
+                    createPhenotypicFeature("HP:0001167", "Abnormality of finger", true),
+                    createPhenotypicFeature("HP:0001166", "Arachnodactyly", false)
+            ).build();
+
+            List<ValidationResult> results = validator.validate(pp);
+
+            assertThat(results, hasSize(1));
+            ValidationResult result = results.get(0);
+            assertThat(result.level(), equalTo(ValidationLevel.ERROR));
+            assertThat(result.category(), equalTo("Violation of the annotation propagation rule"));
+            assertThat(result.message(), equalTo("Phenotypic features of example-phenopacket must not contain both an observed term (Arachnodactyly, HP:0001166) and an excluded ancestor (Abnormality of finger, HP:0001167)"));
+        }
+
+        private static Phenopacket.Builder createPhenopacket(PhenotypicFeature excludedArachnodactyly, PhenotypicFeature observedAbnormalityOfFinger) {
+            return Phenopacket.newBuilder()
+                    .setId("example-phenopacket")
+                    .addPhenotypicFeatures(excludedArachnodactyly)
+                    .addPhenotypicFeatures(observedAbnormalityOfFinger);
+        }
+
+        private static PhenotypicFeature createPhenotypicFeature(String id, String label, boolean excluded) {
+            return PhenotypicFeature.newBuilder()
+                    .setType(OntologyClass.newBuilder()
+                            .setId(id)
+                            .setLabel(label)
+                            .build())
+                    .setExcluded(excluded)
+                    .build();
+        }
+    }
+
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/PrimaryHpoPhenotypeValidatorTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/PrimaryHpoPhenotypeValidatorTest.java
@@ -5,30 +5,29 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
 import org.phenopackets.phenopackettools.validator.core.TestData;
 import org.phenopackets.phenopackettools.validator.core.ValidationLevel;
 import org.phenopackets.phenopackettools.validator.core.ValidationResult;
-import org.phenopackets.schema.v2.Cohort;
-import org.phenopackets.schema.v2.Family;
-import org.phenopackets.schema.v2.Phenopacket;
+import org.phenopackets.schema.v2.*;
 
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-public class HpoPhenotypeValidatorTest {
+public class PrimaryHpoPhenotypeValidatorTest {
 
     private static final Ontology HPO = TestData.HPO;
 
     @Nested
     public class PhenopacketTest {
 
-        private PhenopacketHpoPhenotypeValidator validator;
+        private PhenopacketValidator<PhenopacketOrBuilder> validator;
 
         @BeforeEach
         public void setUp() {
-            validator = new PhenopacketHpoPhenotypeValidator(HPO);
+            validator = HpoPhenotypeValidators.Primary.phenopacketHpoPhenotypeValidator(HPO);
         }
 
         @Test
@@ -152,11 +151,11 @@ public class HpoPhenotypeValidatorTest {
      */
     @Nested
     public class FamilyTest {
-        private FamilyHpoPhenotypeValidator validator;
+        private PhenopacketValidator<FamilyOrBuilder> validator;
 
         @BeforeEach
         public void setUp() {
-            validator = new FamilyHpoPhenotypeValidator(HPO);
+            validator = HpoPhenotypeValidators.Primary.familyHpoPhenotypeValidator(HPO);
         }
 
         @Test
@@ -306,11 +305,11 @@ public class HpoPhenotypeValidatorTest {
     @Nested
     public class CohortTest {
 
-        private CohortHpoPhenotypeValidator validator;
+        private PhenopacketValidator<CohortOrBuilder> validator;
 
         @BeforeEach
         public void setUp() {
-            validator = new CohortHpoPhenotypeValidator(HPO);
+            validator = HpoPhenotypeValidators.Primary.cohortHpoPhenotypeValidator(HPO);
         }
 
         @Test


### PR DESCRIPTION
Ensure phenopacket does not contain both an HPO term and an ancestor. 

A phenopacket should not contain a feature and its ancestor. This applies to both observed and excluded phenotypic features. In case of observed features, the most specific feature should be retained. In contrary, the least specific (broadest) feature should be retained for the excluded phenotypic features.

As an exception, an observed ancestor of an excluded feature can be included (e.g. _Abnormality of finger_ but **not** _Arachnodactyly_).