### PR TITLE
Implement organ systems validator

### DIFF
--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
@@ -1,14 +1,20 @@
 package org.phenopackets.phenopackettools.validator.core.phenotype;
 
 import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.phenopackets.phenopackettools.validator.core.PhenopacketValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.CohortHpoAncestryValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.FamilyHpoAncestryValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.ancestry.PhenopacketHpoAncestryValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.orgsys.CohortHpoOrganSystemValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.orgsys.FamilyHpoOrganSystemValidator;
+import org.phenopackets.phenopackettools.validator.core.phenotype.orgsys.PhenopacketHpoOrganSystemValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.primary.CohortHpoPhenotypeValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.primary.FamilyHpoPhenotypeValidator;
 import org.phenopackets.phenopackettools.validator.core.phenotype.primary.PhenopacketHpoPhenotypeValidator;
 import org.phenopackets.schema.v2.*;
+
+import java.util.Collection;
 
 /**
  * Static factory class for getting {@link PhenopacketValidator}s for top-level Phenopacket schema components.
@@ -133,6 +139,68 @@ public class HpoPhenotypeValidators {
          */
         public static PhenopacketValidator<CohortOrBuilder> cohortHpoAncestryValidator(Ontology hpo) {
             return new CohortHpoAncestryValidator(hpo);
+        }
+    }
+
+    /**
+     * A static factory class for providing validators for checking annotation of organ systems.
+     * <p>
+     * The validators check if each phenopacket or family/cohort member have annotation
+     * for an organ system represented by a top-level HPO term
+     * (e.g. <a href="https://hpo.jax.org/app/browse/term/HP:0040064">Abnormality of limbs</a>).
+     * The annotation comprises either one or more observed descendants
+     * (e.g. <a href="https://hpo.jax.org/app/browse/term/HP:0001166">Arachnodactyly</a>),
+     * or excluded top-level HPO term
+     * (<em>NOT</em> <a href="https://hpo.jax.org/app/browse/term/HP:0040064">Abnormality of limbs</a>).
+     * <p>
+     */
+    public static class OrganSystem {
+        private OrganSystem() {
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate annotation of organ systems in a {@link Phenopacket}
+         * using provided {@link Ontology} and a collection of organ system {@link TermId}s.
+         * <p>
+         * <b>NOTE:</b> the organ system {@link TermId} that is absent from the {@link Ontology} is disregarded
+         * and not used for validation.
+         *
+         * @param hpo HPO ontology
+         * @param organSystemTermIds a collection of HPO {@link TermId}s corresponding to organ systems.
+         */
+        public static PhenopacketValidator<PhenopacketOrBuilder> phenopacketHpoOrganSystemValidator(Ontology hpo,
+                                                                                                    Collection<TermId> organSystemTermIds) {
+            return new PhenopacketHpoOrganSystemValidator(hpo, organSystemTermIds);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate annotation of organ systems in a {@link Family}
+         * using provided {@link Ontology} and a collection of organ system {@link TermId}s.
+         * <p>
+         * <b>NOTE:</b> the organ system {@link TermId} that is absent from the {@link Ontology} is disregarded
+         * and not used for validation.
+         *
+         * @param hpo HPO ontology
+         * @param organSystemTermIds a collection of HPO {@link TermId}s corresponding to organ systems.
+         */
+        public static PhenopacketValidator<FamilyOrBuilder> familyHpoOrganSystemValidator(Ontology hpo,
+                                                                                          Collection<TermId> organSystemTermIds) {
+            return new FamilyHpoOrganSystemValidator(hpo, organSystemTermIds);
+        }
+
+        /**
+         * Get {@link PhenopacketValidator} to validate annotation of organ systems in a {@link Cohort}
+         * using provided {@link Ontology} and a collection of organ system {@link TermId}s.
+         * <p>
+         * <b>NOTE:</b> the organ system {@link TermId} that is absent from the {@link Ontology} is disregarded
+         * and not used for validation.
+         *
+         * @param hpo HPO ontology
+         * @param organSystemTermIds a collection of HPO {@link TermId}s corresponding to organ systems.
+         */
+        public static PhenopacketValidator<CohortOrBuilder> cohortHpoOrganSystemValidator(Ontology hpo,
+                                                                                          Collection<TermId> organSystemTermIds) {
+            return new CohortHpoOrganSystemValidator(hpo, organSystemTermIds);
         }
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/AbstractOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/AbstractOrganSystemValidator.java
@@ -20,7 +20,16 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-abstract class AbstractOrganSystemValidator<T extends MessageOrBuilder> extends BaseHpoValidator<T> {
+/**
+ * The base class for an organ system validator to check if each phenopacket or family/cohort member have annotation
+ * for an organ system represented by a top-level HPO term
+ * (e.g. <a href="https://hpo.jax.org/app/browse/term/HP:0040064">Abnormality of limbs</a>).
+ * The annotation comprises either one or more observed descendants
+ * (e.g. <a href="https://hpo.jax.org/app/browse/term/HP:0001166">Arachnodactyly</a>),
+ * or excluded top-level HPO term
+ * (<em>NOT</em> <a href="https://hpo.jax.org/app/browse/term/HP:0040064">Abnormality of limbs</a>).
+ */
+public abstract class AbstractOrganSystemValidator<T extends MessageOrBuilder> extends BaseHpoValidator<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOrganSystemValidator.class);
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/AbstractOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/AbstractOrganSystemValidator.java
@@ -1,0 +1,117 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.orgsys;
+
+import com.google.protobuf.MessageOrBuilder;
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+import org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.Term;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.phenopackettools.validator.core.ValidationResult;
+import org.phenopackets.phenopackettools.validator.core.ValidatorInfo;
+import org.phenopackets.phenopackettools.validator.core.phenotype.base.BaseHpoValidator;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+import org.phenopackets.schema.v2.core.OntologyClass;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+abstract class AbstractOrganSystemValidator<T extends MessageOrBuilder> extends BaseHpoValidator<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOrganSystemValidator.class);
+
+    private static final ValidatorInfo VALIDATOR_INFO = ValidatorInfo.of(
+            "HpoOrganSystemValidator",
+            "HPO organ system validator",
+            "Validate that HPO terms are well formatted, present, and non-obsolete based on the provided HPO");
+
+    private static final String MISSING_ORGAN_SYSTEM_CATEGORY = "Missing organ system annotation";
+
+    protected final List<TermId> organSystemTermIds;
+
+    protected AbstractOrganSystemValidator(Ontology hpo,
+                                           Collection<TermId> organSystemTermIds) {
+        super(hpo);
+        this.organSystemTermIds = Objects.requireNonNull(organSystemTermIds).stream()
+                .distinct()
+                .filter(organSystemTermIdIsInOntology(hpo))
+                .sorted()
+                .toList();
+    }
+
+    private static Predicate<TermId> organSystemTermIdIsInOntology(Ontology hpo) {
+        return organSystemTermId -> {
+            if (hpo.containsTerm(organSystemTermId)) {
+                return true;
+            } else {
+                LOGGER.warn("{} is not present in the ontology", organSystemTermId.getValue());
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public ValidatorInfo validatorInfo() {
+        return VALIDATOR_INFO;
+    }
+
+    @Override
+    public List<ValidationResult> validate(T component) {
+        return getPhenopackets(component)
+                .flatMap(p -> checkPhenotypicFeatures(p.getSubject().getId(), p.getPhenotypicFeaturesList()))
+                .toList();
+    }
+
+    protected abstract Stream<? extends PhenopacketOrBuilder> getPhenopackets(T component);
+
+    private Stream<ValidationResult> checkPhenotypicFeatures(String individualId, List<PhenotypicFeature> features) {
+        // Get a list of observed phenotypic feature term IDs.
+        List<TermId> phenotypeFeatures = features.stream()
+                .filter(pf -> !pf.getExcluded()) // TODO - should we only work with the observed features?
+                .map(PhenotypicFeature::getType)
+                .map(toTermId(individualId))
+                .flatMap(Optional::stream)
+                .toList();
+
+
+        Stream.Builder<ValidationResult> results = Stream.builder();
+        // Check we have at least one phenotypeFeature (pf) that is a descendant of given organSystemId
+        // and report otherwise.
+        organSystemLoop:
+        for (TermId organSystemId : organSystemTermIds) {
+            for (TermId pf : phenotypeFeatures) {
+                if (OntologyAlgorithm.existsPath(hpo, pf, organSystemId)) {
+                    continue organSystemLoop; // It only takes one termId to annotate an organ system.
+                }
+            }
+
+            // If we get here, then the organSystemId is not annotated, and we report a validation error.
+            Term organSystem = hpo.getTermMap().get(organSystemId);
+            ValidationResult result = ValidationResult.error(VALIDATOR_INFO,
+                    MISSING_ORGAN_SYSTEM_CATEGORY,
+                    "Missing annotation for %s [%s] in '%s'"
+                            .formatted(organSystem.getName(), organSystem.id().getValue(), individualId));
+            results.add(result);
+        }
+
+        return results.build();
+    }
+
+    /**
+     * @return a function that maps {@link OntologyClass} into a {@link TermId} and emit warning otherwise.
+     */
+    private static Function<OntologyClass, Optional<TermId>> toTermId(String individualId) {
+        return oc -> {
+            try {
+                return Optional.of(TermId.of(oc.getId()));
+            } catch (PhenolRuntimeException e) {
+                LOGGER.warn("Invalid term ID {} in individual {}", oc.getId(), individualId);
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/CohortHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/CohortHpoOrganSystemValidator.java
@@ -1,0 +1,23 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.orgsys;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.schema.v2.CohortOrBuilder;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+public class CohortHpoOrganSystemValidator extends AbstractOrganSystemValidator<CohortOrBuilder> {
+
+    protected CohortHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
+        super(hpo, organSystemTermIds);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> getPhenopackets(CohortOrBuilder component) {
+        return component.getMembersOrBuilderList().stream();
+    }
+
+
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/CohortHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/CohortHpoOrganSystemValidator.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 
 public class CohortHpoOrganSystemValidator extends AbstractOrganSystemValidator<CohortOrBuilder> {
 
-    protected CohortHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
+    public CohortHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
         super(hpo, organSystemTermIds);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/FamilyHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/FamilyHpoOrganSystemValidator.java
@@ -10,7 +10,7 @@ import java.util.stream.Stream;
 
 public class FamilyHpoOrganSystemValidator extends AbstractOrganSystemValidator<FamilyOrBuilder> {
 
-    protected FamilyHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
+    public FamilyHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
         super(hpo, organSystemTermIds);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/FamilyHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/FamilyHpoOrganSystemValidator.java
@@ -1,0 +1,25 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.orgsys;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.schema.v2.FamilyOrBuilder;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+public class FamilyHpoOrganSystemValidator extends AbstractOrganSystemValidator<FamilyOrBuilder> {
+
+    protected FamilyHpoOrganSystemValidator(Ontology hpo, Collection<TermId> organSystemTermIds) {
+        super(hpo, organSystemTermIds);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> getPhenopackets(FamilyOrBuilder component) {
+        return Stream.concat(
+                Stream.of(component.getProband()),
+                component.getRelativesList().stream()
+        );
+    }
+
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/PhenopacketHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/PhenopacketHpoOrganSystemValidator.java
@@ -1,0 +1,21 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.orgsys;
+
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.schema.v2.PhenopacketOrBuilder;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class PhenopacketHpoOrganSystemValidator extends AbstractOrganSystemValidator<PhenopacketOrBuilder> {
+
+    public PhenopacketHpoOrganSystemValidator(Ontology hpo,
+                                              List<TermId> organSystemTerms) {
+        super(hpo, organSystemTerms);
+    }
+
+    @Override
+    protected Stream<? extends PhenopacketOrBuilder> getPhenopackets(PhenopacketOrBuilder component) {
+        return Stream.of(component);
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/PhenopacketHpoOrganSystemValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/orgsys/PhenopacketHpoOrganSystemValidator.java
@@ -4,13 +4,13 @@ import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
 import org.phenopackets.schema.v2.PhenopacketOrBuilder;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Stream;
 
 public class PhenopacketHpoOrganSystemValidator extends AbstractOrganSystemValidator<PhenopacketOrBuilder> {
 
     public PhenopacketHpoOrganSystemValidator(Ontology hpo,
-                                              List<TermId> organSystemTerms) {
+                                              Collection<TermId> organSystemTerms) {
         super(hpo, organSystemTerms);
     }
 

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/MaybeExcludedTermId.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/MaybeExcludedTermId.java
@@ -1,0 +1,20 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.util;
+
+import org.monarchinitiative.phenol.base.PhenolRuntimeException;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+
+import java.util.Optional;
+
+record MaybeExcludedTermId(TermId termId, boolean excluded) {
+
+    static Optional<MaybeExcludedTermId> fromPhenotypicFeature(PhenotypicFeature phenotypicFeature) {
+        TermId termId;
+        try {
+            termId = TermId.of(phenotypicFeature.getType().getId());
+        } catch (PhenolRuntimeException e) {
+            return Optional.empty();
+        }
+        return Optional.of(new MaybeExcludedTermId(termId, phenotypicFeature.getExcluded()));
+    }
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/PhenotypicFeaturesByExclusionStatus.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/PhenotypicFeaturesByExclusionStatus.java
@@ -1,0 +1,9 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.util;
+
+import org.monarchinitiative.phenol.ontology.data.TermId;
+
+import java.util.Set;
+
+public record PhenotypicFeaturesByExclusionStatus(Set<TermId> observedPhenotypicFeatures,
+                                                  Set<TermId> excludedPhenotypicFeatures) {
+}

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/Util.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/util/Util.java
@@ -1,0 +1,42 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype.util;
+
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Util {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
+
+    private Util() {
+        // static utility class
+    }
+
+    public static PhenotypicFeaturesByExclusionStatus partitionByExclusionStatus(Collection<PhenotypicFeature> phenotypicFeatures) {
+        Map<Boolean, Set<TermId>> byExclusion = phenotypicFeatures.stream()
+                .map(toMaybeObservedTermId())
+                .flatMap(Optional::stream)
+                // Use `partitioningBy` instead of `groupingBy` to ensure the map contains keys
+                // for both `true` and `false`. Then extract `TermId` and collect in a `Set`.
+                .collect(Collectors.partitioningBy(MaybeExcludedTermId::excluded,
+                        Collectors.mapping(MaybeExcludedTermId::termId, Collectors.toSet())));
+        return new PhenotypicFeaturesByExclusionStatus(byExclusion.get(false), byExclusion.get(true));
+    }
+
+    private static Function<PhenotypicFeature, Optional<MaybeExcludedTermId>> toMaybeObservedTermId() {
+        return pf -> MaybeExcludedTermId.fromPhenotypicFeature(pf)
+                .or(() -> {
+                    // Let's log the malformed term.
+                    LOGGER.warn("Skipping validation of malformed term ID {}", pf.getType().getId());
+                    return Optional.empty();
+                });
+    }
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/OrganSystemValidatorTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/OrganSystemValidatorTest.java
@@ -1,0 +1,159 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.phenopackets.phenopackettools.validator.core.*;
+import org.phenopackets.schema.v2.*;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.phenopackets.phenopackettools.validator.core.phenotype.Utils.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class OrganSystemValidatorTest {
+
+    private static final Ontology HPO = TestData.HPO;
+    private static final Set<TermId> ABNORMALITY_OF_LIMBS_ORGAN_SYSTEM = Set.of(TermId.of("HP:0040064"));
+    // Not a real organ system, but for the sake of testing...
+    private static final Set<TermId> SLENDER_FINGER_ORGAN_SYSTEM = Set.of(TermId.of("HP:0001238"));
+
+    @Nested
+    public class PhenopacketTest {
+
+        private PhenopacketValidator<PhenopacketOrBuilder> abnormalityOfLimbValidator;
+        private PhenopacketValidator<PhenopacketOrBuilder> slenderFingerValidator;
+
+        @BeforeEach
+        public void setUp() {
+            abnormalityOfLimbValidator = HpoPhenotypeValidators.OrganSystem.phenopacketHpoOrganSystemValidator(HPO, ABNORMALITY_OF_LIMBS_ORGAN_SYSTEM);
+            slenderFingerValidator = HpoPhenotypeValidators.OrganSystem.phenopacketHpoOrganSystemValidator(HPO, SLENDER_FINGER_ORGAN_SYSTEM);
+        }
+
+        @Test
+        public void noValidationErrorsIfOrganSystemIsAnnotated() {
+            // Has Arachnodactyly.
+            Phenopacket pp = createPhenopacket(
+                    "example-phenopacket", "example-subject",
+                    createPhenotypicFeature("HP:0001166", "Arachnodactyly", false)
+            ).build();
+
+            List<ValidationResult> results = abnormalityOfLimbValidator.validate(pp);
+
+            assertThat(results, is(empty()));
+        }
+
+        @Test
+        public void noValidationErrorsIfOrganSystemAbnormalityIsExcluded() {
+            // Has Arachnodactyly.
+            Phenopacket pp = createPhenopacket(
+                    "example-phenopacket", "example-subject",
+                    createPhenotypicFeature("HP:0040064", "Abnormality of limbs", true)
+            ).build();
+
+            List<ValidationResult> results = abnormalityOfLimbValidator.validate(pp);
+
+            assertThat(results, is(empty()));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "true",
+                "false"
+        })
+        public void annotationAbsenceLeadsToAnError(boolean excluded) {
+            // Long fingers and Slender finger are siblings, hence no annotation here.
+            Phenopacket pp = createPhenopacket(
+                    "example-phenopacket", "example-subject",
+                    createPhenotypicFeature("HP:0100807", "Long fingers", excluded)
+            ).build();
+
+            List<ValidationResult> results = slenderFingerValidator.validate(pp);
+
+            assertThat(results, hasSize(1));
+            ValidationResult result = results.get(0);
+            assertThat(result.validatorInfo(), equalTo(slenderFingerValidator.validatorInfo()));
+            assertThat(result.level(), equalTo(ValidationLevel.ERROR));
+            assertThat(result.category(), equalTo("Missing organ system annotation"));
+            assertThat(result.message(), equalTo("Missing annotation for Slender finger [HP:0001238] in 'example-subject'"));
+        }
+    }
+
+    /**
+     * White-box testing - we know that the {@link PhenotypicFeature} is an attribute of a {@link Phenopacket}, so we
+     * test the validation logic extensively in {@link OrganSystemValidatorTest.PhenopacketTest}.
+     * The {@link OrganSystemValidatorTest.FamilyTest} test suite ensures there are not errors in a valid input.
+     */
+    @Nested
+    public class FamilyTest {
+
+        private PhenopacketValidator<FamilyOrBuilder> abnormalityOfLimbValidator;
+
+        @BeforeEach
+        public void setUp() {
+            abnormalityOfLimbValidator = HpoPhenotypeValidators.OrganSystem.familyHpoOrganSystemValidator(HPO, ABNORMALITY_OF_LIMBS_ORGAN_SYSTEM);
+        }
+
+        @Test
+        public void testValidInput() {
+            Family family = Family.newBuilder()
+                    .setProband(createPhenopacket("example-phenopacket", "example-subject",
+                            createPhenotypicFeature("HP:0001166", "Arachnodactyly", false))
+                            .build())
+                    .addRelatives(createPhenopacket("dad-phenopacket", "example-dad",
+                            createPhenotypicFeature("HP:0001238", "Slender finger", false))
+                            .build())
+                    .addRelatives(createPhenopacket("mom-phenopacket", "other-mom",
+                            createPhenotypicFeature("HP:0100807", "Long fingers", false))
+                            .build())
+                    .build();
+
+            List<ValidationResult> results = abnormalityOfLimbValidator.validate(family);
+
+            assertThat(results, is(empty()));
+        }
+    }
+
+    /**
+     * White-box testing (same as in {@link OrganSystemValidatorTest.FamilyTest}) - we know that the {@link PhenotypicFeature}
+     * is an attribute of a {@link Phenopacket}, so we test the validation logic extensively
+     * in {@link OrganSystemValidatorTest.PhenopacketTest}.
+     * The {@link OrganSystemValidatorTest.CohortTest} test suite ensures there are not errors in valid input.
+     */
+    @Nested
+    public class CohortTest {
+
+        private PhenopacketValidator<CohortOrBuilder> abnormalityOfLimbValidator;
+
+        @BeforeEach
+        public void setUp() {
+            abnormalityOfLimbValidator = HpoPhenotypeValidators.OrganSystem.cohortHpoOrganSystemValidator(HPO, ABNORMALITY_OF_LIMBS_ORGAN_SYSTEM);
+        }
+
+        @Test
+        public void testValidInput() {
+            Cohort cohort = Cohort.newBuilder()
+                    .addMembers(createPhenopacket("joe-phenopacket", "example-subject",
+                            createPhenotypicFeature("HP:0001166", "Arachnodactyly", false))
+                            .build())
+                    .addMembers(createPhenopacket("jim-phenopacket", "example-jim",
+                            createPhenotypicFeature("HP:0001238", "Slender finger", false))
+                            .build())
+                    .addMembers(createPhenopacket("jane-phenopacket", "example-jane",
+                            createPhenotypicFeature("HP:0100807", "Long fingers", false))
+                            .build())
+                    .build();
+
+            List<ValidationResult> results = abnormalityOfLimbValidator.validate(cohort);
+
+            assertThat(results, is(empty()));
+        }
+    }
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/Utils.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/Utils.java
@@ -1,0 +1,33 @@
+package org.phenopackets.phenopackettools.validator.core.phenotype;
+
+import org.phenopackets.schema.v2.Phenopacket;
+import org.phenopackets.schema.v2.core.Individual;
+import org.phenopackets.schema.v2.core.OntologyClass;
+import org.phenopackets.schema.v2.core.PhenotypicFeature;
+
+import java.util.Arrays;
+
+public class Utils {
+
+    static Phenopacket.Builder createPhenopacket(String phenopacketId,
+                                                 String subjectId,
+                                                 PhenotypicFeature... features) {
+        return Phenopacket.newBuilder()
+                .setId(phenopacketId)
+                .setSubject(Individual.newBuilder()
+                        .setId(subjectId)
+                        .build())
+                .addAllPhenotypicFeatures(Arrays.asList(features));
+    }
+
+    static PhenotypicFeature createPhenotypicFeature(String id, String label, boolean excluded) {
+        return PhenotypicFeature.newBuilder()
+                .setType(OntologyClass.newBuilder()
+                        .setId(id)
+                        .setLabel(label)
+                        .build())
+                .setExcluded(excluded)
+                .build();
+    }
+
+}


### PR DESCRIPTION
Addresses the last point of #73 

Add an organ system validator that checks if each phenopacket or family/cohort member have annotation for provided organ system represented by a top-level HPO term (e.g. [Abnormality of limbs](https://hpo.jax.org/app/browse/term/HP:0040064)). The annotation comprises either one or more observed descendants (e.g. [Arachnodactyly](https://hpo.jax.org/app/browse/term/HP:0001166)), or excluded top-level HPO term (NOT [Abnormality of limbs](https://hpo.jax.org/app/browse/term/HP:0040064)).

