### PR TITLE
change miligram per day to milligram per liter

### DIFF
--- a/constants/Unit.tsv
+++ b/constants/Unit.tsv
@@ -12,7 +12,7 @@ UCUM:ug/L	microgram per liter	MICROGRAM_PER_LITER	microgramPerLiter
 UCUM:uL	microliter	MICROLITER	microliter
 UCUM:um	micrometer	MICROMETER	micrometer
 UCUM:mg	milligram	MILLIGRAM	milligram
-UCUM:mg/dL	milligram per day	MILLIGRAM_PER_DAY	milligramPerDay
+UCUM:mg/L	milligram per liter	MILLIGRAM_PER_LITER	milligramPerLiter
 UCUM:mg/dL	milligram per deciliter	MILLIGRAM_PER_DL	milligramPerDeciliter
 UCUM:mg.kg-1	milligram per kilogram	MILLIGRAM_PER_KG	mgPerKg
 UCUM:mL	milliliter	MILLILITER	milliliter

--- a/constants/create_rtd.py
+++ b/constants/create_rtd.py
@@ -87,6 +87,6 @@ The following tables present the available static functions with predefined conc
 
 """
 with open(RTD_PATH, "wt") as fh:
-	fh.write(RTD_HEADER)
-	for e in entries:
-    create_csv_table(e, fh=fh)
+    fh.write(RTD_HEADER)
+    for e in entries:
+        create_csv_table(e, fh=fh)

--- a/docs/constants.rst
+++ b/docs/constants.rst
@@ -238,7 +238,7 @@ With some exceptions, terms from the `The Unified Code for Units of Measure <htt
    "UCUM:uL", "microliter", "microliter()"
    "UCUM:um", "micrometer", "micrometer()"
    "UCUM:mg", "milligram", "milligram()"
-   "UCUM:mg/dL", "milligram per day", "milligramPerDay()"
+   "UCUM:mg/L", "milligram per liter", "milligramPerLiter()"
    "UCUM:mg/dL", "milligram per deciliter", "milligramPerDeciliter()"
    "UCUM:mg.kg-1", "milligram per kilogram", "mgPerKg()"
    "UCUM:mL", "milliliter", "milliliter()"

--- a/phenopacket-tools-builder/src/main/java/org/phenopackets/phenopackettools/builder/constants/Unit.java
+++ b/phenopacket-tools-builder/src/main/java/org/phenopackets/phenopackettools/builder/constants/Unit.java
@@ -18,7 +18,7 @@ public class Unit {
   private static final OntologyClass MICROLITER = OntologyClassBuilder.ontologyClass("UCUM:uL", "microliter");
   private static final OntologyClass MICROMETER = OntologyClassBuilder.ontologyClass("UCUM:um", "micrometer");
   private static final OntologyClass MILLIGRAM = OntologyClassBuilder.ontologyClass("UCUM:mg", "milligram");
-  private static final OntologyClass MILLIGRAM_PER_DAY = OntologyClassBuilder.ontologyClass("UCUM:mg/dL", "milligram per day");
+  private static final OntologyClass MILLIGRAM_PER_LITER = OntologyClassBuilder.ontologyClass("UCUM:mg/L", "milligram per liter");
   private static final OntologyClass MILLIGRAM_PER_DL = OntologyClassBuilder.ontologyClass("UCUM:mg/dL", "milligram per deciliter");
   private static final OntologyClass MILLIGRAM_PER_KG = OntologyClassBuilder.ontologyClass("UCUM:mg.kg-1", "milligram per kilogram");
   private static final OntologyClass MILLILITER = OntologyClassBuilder.ontologyClass("UCUM:mL", "milliliter");
@@ -44,7 +44,7 @@ public class Unit {
   public static OntologyClass microliter() { return MICROLITER; }
   public static OntologyClass micrometer() { return MICROMETER; }
   public static OntologyClass milligram() { return MILLIGRAM; }
-  public static OntologyClass milligramPerDay() { return MILLIGRAM_PER_DAY; }
+  public static OntologyClass milligramPerLiter() { return MILLIGRAM_PER_LITER; }
   public static OntologyClass milligramPerDeciliter() { return MILLIGRAM_PER_DL; }
   public static OntologyClass mgPerKg() { return MILLIGRAM_PER_KG; }
   public static OntologyClass milliliter() { return MILLILITER; }


### PR DESCRIPTION
Fixes #129

But please check with @pnrobinson what was intended here before merging, I assume that even though mg per day is a valid derived unit it's not what was intended