### PR TITLE
Core is a transitive requirement of IO.

### DIFF
--- a/phenopacket-tools-io/src/main/java/module-info.java
+++ b/phenopacket-tools-io/src/main/java/module-info.java
@@ -2,6 +2,7 @@
  * A module for reading and writing top-level elements of Phenopacket Schema.
  */
 module org.phenopackets.phenopackettools.io {
+    requires transitive org.phenopackets.phenopackettools.core; // due to being part of PhenopacketPrinterFactory API
     requires org.phenopackets.phenopackettools.util;
 
     requires org.phenopackets.schema;


### PR DESCRIPTION
`phenopackettools.core` is a transitive requirement of `phenopackettools.io`.