### PR TITLE
Fix varargs CLI options

### DIFF
--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/Main.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/Main.java
@@ -48,6 +48,7 @@ public class Main {
         Locale.setDefault(Locale.US);
         //noinspection InstantiationOfUtilityClass
         CommandLine cline = new CommandLine(new Main())
+                .setUnmatchedOptionsArePositionalParams(false)
                 .setColorScheme(COLOR_SCHEME);
         cline.getSubcommands().get("generate-completion").getCommandSpec().usageMessage().hidden(true);
         System.exit(cline.execute(args));

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/ConvertCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/ConvertCommand.java
@@ -62,7 +62,9 @@ public class ConvertCommand extends BaseIOCommand {
 
         // (2) Convert into v2 format.
         if (convertSection.convertVariants)
-            LOGGER.debug("Converting variants");
+            LOGGER.info("Converting variants");
+        else
+            LOGGER.info("Ignoring variants since the `--convert-variants` option is unset");
 
         V1ToV2Converter converter = V1ToV2Converter.of(convertSection.convertVariants);
         List<MessageAndPath> converted = new ArrayList<>(messages.size());

--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/ValidateCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/ValidateCommand.java
@@ -49,7 +49,6 @@ public class ValidateCommand extends BaseIOCommand {
         public boolean includeHeader = false;
 
         @CommandLine.Option(names = {"--require"},
-                arity = "*",
                 description = "Path to JSON schema with additional requirements to enforce.")
         public List<Path> requirements = List.of();
 
@@ -58,7 +57,6 @@ public class ValidateCommand extends BaseIOCommand {
         public Path hpJson;
 
         @CommandLine.Option(names = {"-s", "--organ-system"},
-                arity = "*",
                 description = {"Organ system HPO term IDs",
                         "Default: empty"})
         public List<String> organSystems = List.of();


### PR DESCRIPTION
Cli does not interpret positional parameters as varargs when using `--require` and `--organ-system` options.