### PR TITLE
Improve format and element sniffing

### DIFF
--- a/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/BaseIOCommand.java
+++ b/phenopacket-tools-cli/src/main/java/org/phenopackets/phenopackettools/cli/command/BaseIOCommand.java
@@ -131,18 +131,17 @@ public abstract class BaseIOCommand extends BaseCommand {
         }
 
         // Set element.
-        PhenopacketElement element = ElementSniffer.sniff(is, schemaVersion, inputSection.format);
+        PhenopacketElement element = ElementSniffer.sniff(is, inputSection.format);
         if (inputSection.element == null) {
             LOGGER.info("Input element type (-e | --element) was not provided, making an educated guess..");
             LOGGER.info("The input looks like a {} ", element);
             inputSection.element = element;
         }
-//        else {
-            // TODO - enable once element sniffing is implemented
-//            if (!inputSection.element.equals(element))
+        else {
+            if (!inputSection.element.equals(element))
 //                 Let's go an extra mile and check for the user.
-//                LOGGER.warn("Input element is set to {} but the current input looks like a {}", inputSection.element, element);
-//        }
+                LOGGER.warn("Input element is set to {} but the current input looks like a {}", inputSection.element, element);
+        }
     }
 
     protected record MessageAndPath(Message message, Path path) {}

--- a/phenopacket-tools-io/src/main/java/org/phenopackets/phenopackettools/io/PhenopacketParser.java
+++ b/phenopacket-tools-io/src/main/java/org/phenopackets/phenopackettools/io/PhenopacketParser.java
@@ -1,6 +1,7 @@
 package org.phenopackets.phenopackettools.io;
 
 import com.google.protobuf.Message;
+import org.phenopackets.phenopackettools.util.format.ElementSniffer;
 import org.phenopackets.phenopackettools.util.format.FormatSniffer;
 import org.phenopackets.phenopackettools.core.PhenopacketElement;
 import org.phenopackets.phenopackettools.core.PhenopacketFormat;
@@ -27,8 +28,12 @@ public interface PhenopacketParser {
     // We need to detect the element.
 
     default Message parse(PhenopacketFormat format, InputStream is) throws IOException {
-        PhenopacketElement element = sniffElement(is);
-        return parse(format, element, is);
+        try {
+            PhenopacketElement element = sniffElement(is, format);
+            return parse(format, element, is);
+        } catch (SniffException e) {
+            throw new IOException(e);
+        }
     }
 
     default Message parse(PhenopacketFormat format, Path path) throws IOException {
@@ -65,8 +70,8 @@ public interface PhenopacketParser {
 
     /* ******************************************* UTILITY METHODS ******************************************* */
 
-    private static PhenopacketElement sniffElement(InputStream is) {
-        return PhenopacketElement.PHENOPACKET; // TODO - implement
+    private static PhenopacketElement sniffElement(InputStream is, PhenopacketFormat format) throws SniffException, IOException {
+        return ElementSniffer.sniff(is, format);
     }
 
     private static PhenopacketFormat sniffFormat(InputStream is) throws SniffException, IOException {

--- a/phenopacket-tools-util/src/main/java/module-info.java
+++ b/phenopacket-tools-util/src/main/java/module-info.java
@@ -7,7 +7,6 @@ module org.phenopackets.phenopackettools.util {
     // The `print` package exposes `JsonFormat.Printer`, hence the transitive export.
     requires transitive com.google.protobuf.util;
     requires org.phenopackets.schema;
-    requires org.slf4j;
 
     exports org.phenopackets.phenopackettools.util.format;
     exports org.phenopackets.phenopackettools.util.print;

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
@@ -115,7 +115,7 @@ public class ElementSniffer {
 
     /**
      * Determine the candidate {@link PhenopacketElement} based on candidate field names.
-     *
+     * <p>
      * The code attempts to find discriminatory fields; the fields that are unique to specific top-level element.
      *
      * @param candidateFieldNames an iterable with candidate field names.

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
@@ -3,11 +3,16 @@ package org.phenopackets.phenopackettools.util.format;
 import org.phenopackets.phenopackettools.core.PhenopacketElement;
 import org.phenopackets.phenopackettools.core.PhenopacketFormat;
 import org.phenopackets.phenopackettools.core.PhenopacketSchemaVersion;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Make an educated guess regarding which top-level element of Phenopacket schema is represented in the provided
@@ -15,13 +20,35 @@ import java.io.InputStream;
  */
 public class ElementSniffer {
 
-    // Remove SLF4J from module-info if we omit logging.
-    private static final Logger LOGGER = LoggerFactory.getLogger(ElementSniffer.class);
+    // Top-level fields unique to a phenopacket, both v1 and v2. If we see this field, the content must be a phenopacket.
+    private static final List<String> PHENOPACKET_FIELDS = List.of(
+            "subject", "phenotypicFeatures", "measurements", "interpretations", "medicalActions",
+            "biosamples", "genes", "variants", "diseases"
+    );
+
+    // Top-level fields unique to a family, both v1 and v2. If we see this field, the content must be a family.
+    private static final List<String> FAMILY_FIELDS = List.of(
+            "proband", "relatives", "pedigree"
+    );
+
+    // Top-level fields UNIQUE to a cohort, both v1 and v2. If we see this field, the content must be a cohort.
+    private static final List<String> COHORT_FIELDS = List.of(
+            "description", "members"
+    );
+
+    // Fields shared by all top-level elements:
+    // List.of("id", "htsFiles", "files", "metaData")
+
+    // We can leverage the indention feature of the YAML format to get the top-level field names.
+    private static final Pattern YAML_TOP_LEVEL_FIELD = Pattern.compile("^(?<field>\\w+):");
+
+    // Pattern for matching JSON field.
+    private static final Pattern JSON_FIELD = Pattern.compile("\"(?<field>\\w+)\"\\s*:");
 
     /**
      * The number of bytes used for element sniffing.
      */
-    static final int BUFFER_SIZE = 32;
+    private static final int BUFFER_SIZE = 1024;
 
     private ElementSniffer() {
     }
@@ -39,7 +66,7 @@ public class ElementSniffer {
     public static PhenopacketElement sniff(InputStream input,
                                            PhenopacketSchemaVersion schemaVersion,
                                            PhenopacketFormat format) throws IOException, SniffException {
-        return sniff(Util.getFirstBytesAndReset(input, BUFFER_SIZE), schemaVersion, format);
+        return sniff(Util.getAtMostNFirstBytesAndReset(input, BUFFER_SIZE), schemaVersion, format);
     }
 
     /**
@@ -48,39 +75,132 @@ public class ElementSniffer {
      * @param payload buffer with at least the first {@link #BUFFER_SIZE} bytes of the input.
      * @param format  the {@code payload} format
      * @return the sniffed {@link PhenopacketElement}.
-     * @throws ElementSniffException if {@code payload} contains less than {@link #BUFFER_SIZE} bytes.
+     * @throws ElementSniffException if the payload looks suspicious, e.g. contains a unique phenopacket field
+     * and a unique cohort field at the same time
      */
     public static PhenopacketElement sniff(byte[] payload,
                                            PhenopacketSchemaVersion schemaVersion,
                                            PhenopacketFormat format) throws ElementSniffException {
-        if (payload.length < BUFFER_SIZE)
-            throw new ElementSniffException("Need at least %d bytes to sniff but got %d".formatted(BUFFER_SIZE, payload.length));
-
         return switch (format) {
             case PROTOBUF -> sniffProtobuf(payload, schemaVersion);
-            case JSON -> sniffJson(payload, schemaVersion);
-            case YAML -> sniffYaml(payload, schemaVersion);
+            case JSON -> sniffJson(payload);
+            case YAML -> sniffYaml(payload);
         };
     }
 
-    private static PhenopacketElement sniffProtobuf(byte[] payload, PhenopacketSchemaVersion schemaVersion) {
+    private static PhenopacketElement sniffProtobuf(byte[] payload, PhenopacketSchemaVersion schemaVersion) throws ElementSniffException {
         // TODO - implement
-        LOGGER.debug("Sniffing is not yet implemented, assuming {}", PhenopacketElement.PHENOPACKET);
-        return PhenopacketElement.PHENOPACKET;
+        // possibly using https://protobuf.dev/programming-guides/encoding/
+        throw new ElementSniffException("Element sniffing from protobuf input is not yet implemented");
     }
 
-    private static PhenopacketElement sniffJson(byte[] payload, PhenopacketSchemaVersion schemaVersion) {
-        // TODO - implement
-        // TODO - reconsider the sniffing workflow. In case of loosely defined formats like JSON and YAML,
-        //  the fields can be in any order and we may not get enough information.
-        //  Is it OK to throw upon sniffing failure or an Optional is enough?
-        LOGGER.debug("Sniffing is not yet implemented, assuming {}", PhenopacketElement.PHENOPACKET);
-        return PhenopacketElement.PHENOPACKET;
+    private static PhenopacketElement sniffJson(byte[] payload) throws ElementSniffException {
+        List<String> topLevelFields = findTopLevelFieldNames(payload);
+        return findPhenopacketElement(topLevelFields);
     }
 
-    private static PhenopacketElement sniffYaml(byte[] payload, PhenopacketSchemaVersion schemaVersion) {
-        // TODO - implement
-        LOGGER.debug("Sniffing is not yet implemented, assuming {}", PhenopacketElement.PHENOPACKET);
-        return PhenopacketElement.PHENOPACKET;
+    private static PhenopacketElement sniffYaml(byte[] payload) throws ElementSniffException {
+        String string = new String(payload, StandardCharsets.UTF_8);
+        List<String> candidates = Arrays.stream(string.split("\n"))
+                .flatMap(line -> {
+                    Matcher matcher = YAML_TOP_LEVEL_FIELD.matcher(line);
+                    return matcher.find()
+                            ? Stream.of(matcher.group("field")) 
+                            : Stream.empty();
+                })
+                .toList();
+
+        return findPhenopacketElement(candidates);
     }
+
+    /**
+     * Determine the candidate {@link PhenopacketElement} based on candidate field names.
+     *
+     * The code attempts to find discriminatory fields; the fields that are unique to specific top-level element.
+     *
+     * @param candidateFieldNames an iterable with candidate field names.
+     * @return the resulting {@link PhenopacketElement}.
+     * @throws ElementSniffException if the input is inconsistent (contains fields unique
+     * to different top-level elements (e.g. members ({@code Cohort}) and pedigree ({@code Family})))
+     * or if sniffing is inconclusive (no discriminatory field was found).
+     */
+    private static PhenopacketElement findPhenopacketElement(Iterable<String> candidateFieldNames) throws ElementSniffException {
+        PhenopacketElement candidate = null;
+        String culprit = null; // The field that determined the candidate above.
+        for (String field : candidateFieldNames) {
+            if (PHENOPACKET_FIELDS.contains(field)) {
+                if (candidate == null) {
+                    culprit = field;
+                    candidate = PhenopacketElement.PHENOPACKET;
+                } else {
+                    if (candidate != PhenopacketElement.PHENOPACKET) {
+                        String message = "Inconsistent field names - %s supports %s but %s supports %s"
+                                .formatted(field, PhenopacketElement.PHENOPACKET, culprit, candidate);
+                        throw new ElementSniffException(message);
+                    }
+                }
+            } else if (FAMILY_FIELDS.contains(field)) {
+                if (candidate == null) {
+                    culprit = field;
+                    candidate = PhenopacketElement.FAMILY;
+                } else {
+                    if (candidate != PhenopacketElement.FAMILY) {
+                        String message = "Inconsistent field names - %s supports %s but %s supporting %s"
+                                .formatted(field, PhenopacketElement.FAMILY, culprit, candidate);
+                        throw new ElementSniffException(message);
+                    }
+                }
+            } else if (COHORT_FIELDS.contains(field)) {
+                if (candidate == null) {
+                    culprit = field;
+                    candidate = PhenopacketElement.COHORT;
+                } else {
+                    if (candidate != PhenopacketElement.COHORT) {
+                        String message = "Inconsistent field names - %s supports %s but %s supports %s"
+                                .formatted(field, PhenopacketElement.COHORT, culprit, candidate);
+                        throw new ElementSniffException(message);
+                    }
+                }
+            }
+        }
+
+        if (candidate == null)
+            throw new ElementSniffException("Inconclusive element sniffing");
+
+        return candidate;
+    }
+
+    private static List<String> findTopLevelFieldNames(byte[] payload) {
+        int cursor = 0;
+        int objectLevel = 0;
+        int arrayLevel = 0;
+
+        List<String> fields = new ArrayList<>();
+
+        String string = new String(payload, StandardCharsets.UTF_8);
+        Matcher matcher = JSON_FIELD.matcher(string);
+
+
+        while (matcher.find()) {
+            String field = matcher.group("field");
+            for (int i = cursor; i < matcher.start(); i++) {
+                switch (string.charAt(i)) {
+                    case '{' -> objectLevel++;
+                    case '[' -> arrayLevel++;
+                    case '}' -> objectLevel--;
+                    case ']' -> arrayLevel--;
+                }
+            }
+
+            if (objectLevel == 1 && arrayLevel == 0)
+                // We are only interested in the top-level fields of the JSON document - i.e. where
+                // the fields at the 1st level of the document that are not in the array.
+                fields.add(field);
+
+            cursor = matcher.end();
+        }
+
+        return fields;
+    }
+
 }

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
@@ -62,11 +62,45 @@ public class ElementSniffer {
      * @throws IOException    in case an error occurs while reading the {@code input}.
      * @throws SniffException if there are not enough bytes available in the {@code input} of if the {@code input} does not
      *                        support {@link InputStream#mark(int)}.
+     * @deprecated in favor of {@link #sniff(InputStream, PhenopacketFormat)}.
      */
+    // REMOVE(v1.0.0)
     public static PhenopacketElement sniff(InputStream input,
                                            PhenopacketSchemaVersion schemaVersion,
                                            PhenopacketFormat format) throws IOException, SniffException {
-        return sniff(Util.getAtMostNFirstBytesAndReset(input, BUFFER_SIZE), schemaVersion, format);
+        return sniff(input, format);
+    }
+
+    /**
+     * Make an educated guess of {@link PhenopacketElement} present in given {@code input}.
+     *
+     * @param input  an {@link InputStream} that supports {@link InputStream#mark(int)}.
+     * @param format the {@code payload} format
+     * @return the sniffed {@link PhenopacketElement}.
+     * @throws IOException    in case an error occurs while reading the {@code input}.
+     * @throws SniffException if there are not enough bytes available in the {@code input} of if the {@code input} does not
+     *                        support {@link InputStream#mark(int)}.
+     */
+    public static PhenopacketElement sniff(InputStream input,
+                                           PhenopacketFormat format) throws IOException, SniffException {
+        return sniff(Util.getAtMostNFirstBytesAndReset(input, BUFFER_SIZE), format);
+    }
+
+    /**
+     * Make an educated guess of {@link PhenopacketElement} based on given {@code payload}.
+     *
+     * @param payload buffer with at least the first {@link #BUFFER_SIZE} bytes of the input.
+     * @param format  the {@code payload} format
+     * @return the sniffed {@link PhenopacketElement}.
+     * @throws ElementSniffException if the payload looks suspicious, e.g. contains a unique phenopacket field
+     * and a unique cohort field at the same time
+     * @deprecated in favor of {@link #sniff(byte[], PhenopacketFormat)}
+     */
+    // REMOVE(v1.0.0)
+    public static PhenopacketElement sniff(byte[] payload,
+                                           PhenopacketSchemaVersion schemaVersion,
+                                           PhenopacketFormat format) throws ElementSniffException {
+        return sniff(payload, format);
     }
 
     /**
@@ -79,16 +113,15 @@ public class ElementSniffer {
      * and a unique cohort field at the same time
      */
     public static PhenopacketElement sniff(byte[] payload,
-                                           PhenopacketSchemaVersion schemaVersion,
                                            PhenopacketFormat format) throws ElementSniffException {
         return switch (format) {
-            case PROTOBUF -> sniffProtobuf(payload, schemaVersion);
+            case PROTOBUF -> sniffProtobuf(payload);
             case JSON -> sniffJson(payload);
             case YAML -> sniffYaml(payload);
         };
     }
 
-    private static PhenopacketElement sniffProtobuf(byte[] payload, PhenopacketSchemaVersion schemaVersion) throws ElementSniffException {
+    private static PhenopacketElement sniffProtobuf(byte[] payload) throws ElementSniffException {
         // TODO - implement
         // possibly using https://protobuf.dev/programming-guides/encoding/
         throw new ElementSniffException("Element sniffing from protobuf input is not yet implemented");

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/ElementSniffer.java
@@ -78,8 +78,7 @@ public class ElementSniffer {
      * @param format the {@code payload} format
      * @return the sniffed {@link PhenopacketElement}.
      * @throws IOException    in case an error occurs while reading the {@code input}.
-     * @throws SniffException if there are not enough bytes available in the {@code input} of if the {@code input} does not
-     *                        support {@link InputStream#mark(int)}.
+     * @throws SniffException if the {@code input} does not support {@link InputStream#mark(int)}.
      */
     public static PhenopacketElement sniff(InputStream input,
                                            PhenopacketFormat format) throws IOException, SniffException {

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffException.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffException.java
@@ -3,7 +3,7 @@ package org.phenopackets.phenopackettools.util.format;
 /**
  * An exception thrown when sniffing of the top-level element of Phenopacket schema cannot be performed.
  */
-public class FormatSniffException extends ElementSniffException {
+public class FormatSniffException extends SniffException {
 
     public FormatSniffException() {
         super();

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
@@ -25,11 +25,8 @@ public class FormatSniffer {
      *
      * @param payload buffer with at least the first {@link #BUFFER_SIZE} bytes of the input.
      * @return the sniffed {@link PhenopacketFormat}.
-     * @throws FormatSniffException if {@code payload} contains less than {@link #BUFFER_SIZE} bytes.
      */
-    public static PhenopacketFormat sniff(byte[] payload) throws FormatSniffException {
-        if (payload.length < BUFFER_SIZE)
-            throw new FormatSniffException("Need at least %d bytes to sniff but got %d".formatted(BUFFER_SIZE, payload.length));
+    public static PhenopacketFormat sniff(byte[] payload) {
         if (Util.looksLikeJson(payload)) {
             return PhenopacketFormat.JSON;
         } else if (Util.looksLikeYaml(payload)) {
@@ -53,6 +50,6 @@ public class FormatSniffer {
      * support {@link InputStream#mark(int)}.
      */
     public static PhenopacketFormat sniff(InputStream input) throws IOException, SniffException {
-        return sniff(Util.getFirstBytesAndReset(input, BUFFER_SIZE));
+        return sniff(Util.getAtMostNFirstBytesAndReset(input, BUFFER_SIZE));
     }
 }

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
@@ -23,7 +23,7 @@ public class FormatSniffer {
     /**
      * Make an educated guess of {@link PhenopacketFormat} based on given {@code payload}.
      *
-     * @param payload buffer with at least the first {@link #BUFFER_SIZE} bytes of the input.
+     * @param payload buffer with a certain number of bytes from the front end of the input.
      * @return the sniffed {@link PhenopacketFormat}.
      */
     public static PhenopacketFormat sniff(byte[] payload) {
@@ -46,8 +46,7 @@ public class FormatSniffer {
      * @param input an {@link InputStream} that supports {@link InputStream#mark(int)}.
      * @return the sniffed {@link PhenopacketFormat}.
      * @throws IOException in case an error occurs while reading the {@code input}.
-     * @throws FormatSniffException if there are not enough bytes available in the {@code input} of if the {@code input} does not
-     * support {@link InputStream#mark(int)}.
+     * @throws SniffException if the {@code input} does not support {@link InputStream#mark(int)}.
      */
     public static PhenopacketFormat sniff(InputStream input) throws IOException, SniffException {
         return sniff(Util.getAtMostNFirstBytesAndReset(input, BUFFER_SIZE));

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/FormatSniffer.java
@@ -13,6 +13,8 @@ public class FormatSniffer {
     /**
      * The number of bytes used for format sniffing.
      */
+    // The longest field name as of now is phenotypicFeatures which is 18 bytes,
+    // hence 32 bytes should be enough for format sniffing.
     static final int BUFFER_SIZE = 32;
 
     private FormatSniffer() {

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
@@ -61,18 +61,11 @@ class Util {
         return matcher.find();
     }
 
-    static byte[] getFirstBytesAndReset(InputStream input, int nBytes) throws SniffException, IOException {
+    static byte[] getAtMostNFirstBytesAndReset(InputStream input, int nBytes) throws SniffException, IOException {
         if (input.markSupported()) {
             byte[] buffer = new byte[nBytes];
             input.mark(nBytes);
-            int read = input.read(buffer);
-            if (read < nBytes) {
-                // We explode because there are not enough bytes available for format sniffing.
-                String message = read < 0
-                        ? "The stream must not be at the end"
-                        : "Need at least %d bytes to sniff the format but only %d was available".formatted(nBytes, read);
-                throw new SniffException(message);
-            }
+            input.read(buffer);
             input.reset();
             return buffer;
         } else

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
@@ -1,34 +1,64 @@
 package org.phenopackets.phenopackettools.util.format;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 class Util {
 
-    private static final Pattern YAML_HEADER = Pattern.compile("((phenopacket)|(family)|(cohort)):");
+    /*
+     Field names of the top-level elements of Phenopacket Schemas v1 and v2.
+     The order of fields in YAML format is not prescribed, hence any of these fields can be present at the first line.
+     YAML uses camelCase for field naming.
+     */
+    private static final String[] FIELD_NAMES = {
+            // Phenopacket
+            "id", "subject", "phenotypicFeatures", "measurements", "biosamples",
+            "interpretations", "diseases", "medicalActions", "files", "metaData",
+            // Family (id, files and metaData are already included)
+            "proband", "relatives", "pedigree",
+            // Cohort (id, files, and metaData are already included)
+            "description", "members",
+            // v1 members
+            "genes", "variants", "resolutionStatus", "diagnosis", "phenopacket", "family"
+    };
+
+    private static final String FIELD_GROUPS = Arrays.stream(FIELD_NAMES)
+            .map("(%s)"::formatted)
+            .collect(Collectors.joining("|", "^(", ")"));
+
+    /*
+    A pattern for a YAML field id followed by an optional value.
+    Examples:
+    - `subject:`
+    - `id: "family-phenopacket"``
+    */
+    private static final Pattern YAML_HEADER = Pattern.compile(FIELD_GROUPS);
+    // Any top-level message of the Phenopacket v1 or v2 schemas is a JSON object (not an array), hence it must start
+    // with a `{` character, optionally prepended with white-space.
+    private static final Pattern JSON_HEAD = Pattern.compile("^\\s*\\{");
 
     private Util() {
         // static utility class
     }
 
     static boolean looksLikeJson(byte[] payload) {
-        String head = new String(payload, 0, FormatSniffer.BUFFER_SIZE);
+        String head = new String(payload, StandardCharsets.UTF_8);
         return looksLikeJson(head);
     }
 
     static boolean looksLikeJson(String head) {
-        return head.replace("\\W+", "").startsWith("{");
+        Matcher matcher = JSON_HEAD.matcher(head);
+        return matcher.find();
     }
 
     static boolean looksLikeYaml(byte[] payload) {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(payload)))) {
-            String line = reader.readLine();
-            Matcher matcher = YAML_HEADER.matcher(line);
-            return matcher.matches();
-        } catch (IOException e) {
-            return false;
-        }
+        String string = new String(payload, StandardCharsets.UTF_8);
+        Matcher matcher = YAML_HEADER.matcher(string);
+        return matcher.find();
     }
 
     static byte[] getFirstBytesAndReset(InputStream input, int nBytes) throws SniffException, IOException {

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/format/Util.java
@@ -57,8 +57,18 @@ class Util {
 
     static boolean looksLikeYaml(byte[] payload) {
         String string = new String(payload, StandardCharsets.UTF_8);
-        Matcher matcher = YAML_HEADER.matcher(string);
-        return matcher.find();
+        for (String line : string.split("\n")) {
+            if (line.startsWith("#"))
+                continue; // comment
+            else if (line.startsWith("---"))
+                continue; // document start
+            else if (line.startsWith("..."))
+                continue; // document end
+            Matcher matcher = YAML_HEADER.matcher(line);
+            if (matcher.find())
+                return true;
+        }
+        return false;
     }
 
     static byte[] getAtMostNFirstBytesAndReset(InputStream input, int nBytes) throws SniffException, IOException {

--- a/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/ElementSnifferTest.java
+++ b/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/ElementSnifferTest.java
@@ -1,11 +1,65 @@
 package org.phenopackets.phenopackettools.util.format;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.phenopackets.phenopackettools.core.PhenopacketElement;
+import org.phenopackets.phenopackettools.core.PhenopacketFormat;
+import org.phenopackets.phenopackettools.core.PhenopacketSchemaVersion;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Path;
+
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 public class ElementSnifferTest {
 
-    // TODO - implement
+    private static final Path BASE_DIR = TestResources.BASE_DIR.resolve("format");
 
+    @ParameterizedTest
+    @CsvSource({
+            "covid.yml,         PHENOPACKET",
+            "cohort.v2.yml,     COHORT",
+            "family.v2.yml,     FAMILY",
+    })
+    public void sniffV2Yaml(String fileName, PhenopacketElement expected) throws Exception {
+        File phenopacketFile = BASE_DIR.resolve(fileName).toFile();
+        try (InputStream is = new BufferedInputStream(new FileInputStream(phenopacketFile))) {
+            PhenopacketElement actual = ElementSniffer.sniff(is, PhenopacketSchemaVersion.V2, PhenopacketFormat.YAML);
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "covid.json,        PHENOPACKET",
+            "cohort.v2.json,    COHORT",
+            "family.v2.json,    FAMILY",
+    })
+    public void sniffV2Json(String fileName, PhenopacketElement expected) throws Exception {
+        File phenopacketFile = BASE_DIR.resolve(fileName).toFile();
+        try (InputStream is = new BufferedInputStream(new FileInputStream(phenopacketFile))) {
+            PhenopacketElement actual = ElementSniffer.sniff(is, PhenopacketSchemaVersion.V2, PhenopacketFormat.JSON);
+            assertThat(actual, equalTo(expected));
+        }
+    }
+
+    @Disabled("Not yet implemented")
+    @ParameterizedTest
+    @CsvSource({
+            "comprehensive-phenopacket.pb,     PHENOPACKET",
+            "comprehensive-cohort.pb,          COHORT",
+            "comprehensive-family.pb,          FAMILY",
+    })
+    public void sniffV2Protobuf(String fileName, PhenopacketElement expected) throws Exception {
+        File phenopacketFile = BASE_DIR.resolve(fileName).toFile();
+        try (InputStream is = new BufferedInputStream(new FileInputStream(phenopacketFile))) {
+            PhenopacketElement actual = ElementSniffer.sniff(is, PhenopacketSchemaVersion.V2, PhenopacketFormat.PROTOBUF);
+            assertThat(actual, equalTo(expected));
+        }
+    }
 }

--- a/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/FormatSnifferTest.java
+++ b/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/FormatSnifferTest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.*;
 
 public class FormatSnifferTest {
 
-    private static final Path BASE_DIR = Path.of("src/test/resources/org/phenopackets/phenopackettools/util/format");
+    private static final Path BASE_DIR = TestResources.BASE_DIR.resolve("format");
 
     @ParameterizedTest
     @CsvSource({

--- a/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/FormatSnifferTest.java
+++ b/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/FormatSnifferTest.java
@@ -19,11 +19,17 @@ public class FormatSnifferTest {
 
     @ParameterizedTest
     @CsvSource({
-            "comprehensive-cohort.pb,         PROTOBUF",
-            "comprehensive-family.pb,         PROTOBUF",
             "comprehensive-phenopacket.pb,    PROTOBUF",
             "covid.json,                      JSON",
             "covid.yml,                       YAML",
+
+            "comprehensive-family.pb,         PROTOBUF",
+            "family.v2.json,                  JSON",
+            "family.v2.yml,                   YAML",
+
+            "comprehensive-cohort.pb,         PROTOBUF",
+            "cohort.v2.json,                  JSON",
+            "cohort.v2.yml,                   YAML",
     })
     public void sniff(String fileName, PhenopacketFormat expected) throws Exception {
         byte[] payload = readAllBytes(fileName);

--- a/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/TestResources.java
+++ b/phenopacket-tools-util/src/test/java/org/phenopackets/phenopackettools/util/format/TestResources.java
@@ -1,0 +1,12 @@
+package org.phenopackets.phenopackettools.util.format;
+
+import java.nio.file.Path;
+
+public class TestResources {
+
+    public static final Path BASE_DIR = Path.of("src/test/resources/org/phenopackets/phenopackettools/util");
+
+    private TestResources() {
+    }
+
+}

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/cohort.v2.json
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/cohort.v2.json
@@ -1,0 +1,90 @@
+{
+  "id": "example-cohort",
+  "description": "An example cohort",
+  "members": [{
+    "id": "cohort-member-1",
+    "subject": {
+      "id": "cohort-member-id-1",
+      "sex": "UNKNOWN_SEX",
+      "karyotypicSex": "UNKNOWN_KARYOTYPE"
+    },
+    "phenotypicFeatures": [{
+      "type": {
+        "id": "HP:0031936",
+        "label": "Delayed ability to walk"
+      },
+      "excluded": false
+    }, {
+      "type": {
+        "id": "HP:0009046",
+        "label": "Difficulty running"
+      },
+      "excluded": false
+    }, {
+      "type": {
+        "id": "HP:0003236",
+        "label": "Elevated circulating creatine kinase concentration"
+      },
+      "excluded": true
+    }],
+    "metaData": {
+      "created": "2022-04-17T10:35:00Z",
+      "createdBy": "biocurator",
+      "resources": [{
+        "id": "hp",
+        "name": "human phenotype ontology",
+        "url": "http://purl.obolibrary.org/obo/hp.owl",
+        "version": "2022-06-11",
+        "namespacePrefix": "HP",
+        "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
+      }],
+      "phenopacketSchemaVersion": "2.0.0"
+    }
+  }, {
+    "id": "cohort-member-2",
+    "subject": {
+      "id": "cohort-member-id-2",
+      "sex": "UNKNOWN_SEX",
+      "karyotypicSex": "UNKNOWN_KARYOTYPE"
+    },
+    "phenotypicFeatures": [{
+      "type": {
+        "id": "HP:0000518",
+        "label": "Cataract"
+      },
+      "excluded": false
+    }, {
+      "type": {
+        "id": "HP:0001647",
+        "label": "Bicuspid aortic valve"
+      },
+      "excluded": true
+    }],
+    "metaData": {
+      "created": "2022-04-17T10:35:00Z",
+      "createdBy": "biocurator",
+      "resources": [{
+        "id": "hp",
+        "name": "human phenotype ontology",
+        "url": "http://purl.obolibrary.org/obo/hp.owl",
+        "version": "2022-06-11",
+        "namespacePrefix": "HP",
+        "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
+      }],
+      "phenopacketSchemaVersion": "2.0.0"
+    }
+  }],
+  "metaData": {
+    "created": "2022-04-17T10:35:00Z",
+    "createdBy": "biocurator",
+    "resources": [{
+      "id": "hp",
+      "name": "human phenotype ontology",
+      "url": "http://purl.obolibrary.org/obo/hp.owl",
+      "version": "2022-06-11",
+      "namespacePrefix": "HP",
+      "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
+    }],
+    "phenopacketSchemaVersion": "2.0.0"
+  }
+}

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/cohort.v2.yml
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/cohort.v2.yml
@@ -1,0 +1,68 @@
+id: "example-cohort"
+description: "An example cohort"
+members:
+- id: "cohort-member-1"
+  subject:
+    id: "cohort-member-id-1"
+    sex: "UNKNOWN_SEX"
+    karyotypicSex: "UNKNOWN_KARYOTYPE"
+  phenotypicFeatures:
+  - type:
+      id: "HP:0031936"
+      label: "Delayed ability to walk"
+    excluded: false
+  - type:
+      id: "HP:0009046"
+      label: "Difficulty running"
+    excluded: false
+  - type:
+      id: "HP:0003236"
+      label: "Elevated circulating creatine kinase concentration"
+    excluded: true
+  metaData:
+    created: "2022-04-17T10:35:00Z"
+    createdBy: "biocurator"
+    resources:
+    - id: "hp"
+      name: "human phenotype ontology"
+      url: "http://purl.obolibrary.org/obo/hp.owl"
+      version: "2022-06-11"
+      namespacePrefix: "HP"
+      iriPrefix: "http://purl.obolibrary.org/obo/HP_"
+    phenopacketSchemaVersion: "2.0.0"
+- id: "cohort-member-2"
+  subject:
+    id: "cohort-member-id-2"
+    sex: "UNKNOWN_SEX"
+    karyotypicSex: "UNKNOWN_KARYOTYPE"
+  phenotypicFeatures:
+  - type:
+      id: "HP:0000518"
+      label: "Cataract"
+    excluded: false
+  - type:
+      id: "HP:0001647"
+      label: "Bicuspid aortic valve"
+    excluded: true
+  metaData:
+    created: "2022-04-17T10:35:00Z"
+    createdBy: "biocurator"
+    resources:
+    - id: "hp"
+      name: "human phenotype ontology"
+      url: "http://purl.obolibrary.org/obo/hp.owl"
+      version: "2022-06-11"
+      namespacePrefix: "HP"
+      iriPrefix: "http://purl.obolibrary.org/obo/HP_"
+    phenopacketSchemaVersion: "2.0.0"
+metaData:
+  created: "2022-04-17T10:35:00Z"
+  createdBy: "biocurator"
+  resources:
+  - id: "hp"
+    name: "human phenotype ontology"
+    url: "http://purl.obolibrary.org/obo/hp.owl"
+    version: "2022-06-11"
+    namespacePrefix: "HP"
+    iriPrefix: "http://purl.obolibrary.org/obo/HP_"
+  phenopacketSchemaVersion: "2.0.0"

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/covid.yml
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/covid.yml
@@ -1,214 +1,213 @@
-phenopacket:
-  id: "arbitrary.phenopacket.id"
-  subject:
-    id: "P123542"
-    timeAtLastEncounter:
-      age:
-        iso8601duration: "P70Y"
-    vitalStatus:
-      status: "DECEASED"
-      causeOfDeath:
-        id: "MONDO:0100096"
-        label: "COVID-19"
-    sex: "MALE"
-  phenotypicFeatures:
-  - type:
-      id: "HP:0001945"
-      label: "Fever "
-    onset:
-      timestamp: "2021-02-01T05:00:00Z"
-  - type:
-      id: "HP:0030157"
-      label: "Flank pain"
-    onset:
-      timestamp: "2021-02-01T05:00:00Z"
-  - type:
-      id: "HP:0000790"
-      label: "Hematuria"
-    onset:
-      timestamp: "2021-02-01T05:00:00Z"
-  - type:
-      id: "HP:0012625"
-      label: "Stage 3 chronic kidney disease"
-    onset:
-      timestamp: "2021-02-01T05:00:00Z"
-  - type:
-      id: "HP:0003326"
-      label: "Myalgia"
-    onset:
-      interval:
-        start: "2020-03-18T00:00:00Z"
-        end: "2020-03-20T00:00:00Z"
-  - type:
-      id: "HP:0002014"
-      label: "Diarrhea"
-    onset:
-      interval:
-        start: "2020-03-18T00:00:00Z"
-        end: "2020-03-20T00:00:00Z"
-  - type:
-      id: "HP:0002094"
-      label: "Dyspnea"
-    onset:
-      interval:
-        start: "2020-03-18T00:00:00Z"
-        end: "2020-03-20T00:00:00Z"
-  - type:
-      id: "HP:0033677"
-      label: "Acute respiratory distress syndrome"
-    onset:
-      timestamp: "2020-03-20T00:00:00Z"
-  measurements:
-  - assay:
-      id: "LOINC:26474-7"
-      label: "Lymphocytes [#/volume] in Blood"
-    value:
-      quantity:
-        unit:
-          id: "NCIT:C67245"
-          label: "Thousand Cells"
-        value: 1.4
-    timeObserved:
-      interval:
-        start: "2019-09-01T00:00:00Z"
-        end: "2020-03-01T00:00:00Z"
-  - assay:
-      id: "LOINC:26474-7"
-      label: "Lymphocytes [#/volume] in Blood"
-    value:
-      quantity:
-        unit:
-          id: "NCIT:C67245"
-          label: "Thousand Cells"
-        value: 0.7
-    timeObserved:
-      timestamp: "2020-03-20T00:00:00Z"
-  diseases:
-  - term:
-      id: "MONDO:0005015"
-      label: "diabetes mellitus"
-    excluded: true
-  - term:
-      id: "MONDO:0004994"
-      label: "cardiomyopathy"
-  - term:
+id: "arbitrary.phenopacket.id"
+subject:
+  id: "P123542"
+  timeAtLastEncounter:
+    age:
+      iso8601duration: "P70Y"
+  vitalStatus:
+    status: "DECEASED"
+    causeOfDeath:
       id: "MONDO:0100096"
       label: "COVID-19"
-    onset:
-      timestamp: "2020-03-17T00:00:00Z"
-  medicalActions:
-  - procedure:
-      code:
-        id: "NCIT:C80473"
-        label: "Left Ventricular Assist Device"
-      performed:
-        timestamp: "2016-01-01T00:00:00Z"
-  - treatment:
-      agent:
-        id: "NCIT:C722"
-        label: "Oxygen"
-      routeOfAdministration:
-        id: "NCIT:C38284"
-        label: "Nasal Route of Administration"
-      doseIntervals:
-      - quantity:
-          unit:
-            id: "NCIT:C67388"
-            label: "Liter per Minute"
-          value: 2.0
-        scheduleFrequency:
-          id: "PATO:0000689"
-          label: "continuous"
-        interval:
-          start: "2021-02-01T18:58:43Z"
-          end: "2021-02-02T08:22:42Z"
-      - quantity:
-          unit:
-            id: "NCIT:C67388"
-            label: "Liter per Minute"
-          value: 50.0
-        scheduleFrequency:
-          id: "PATO:0000689"
-          label: "continuous"
-        interval:
-          start: "2021-02-02T08:22:42Z"
-          end: "2021-02-02T12:22:42Z"
-  - treatment:
-      agent:
-        id: "CHEBI:41879"
-        label: "dexamethasone"
-      doseIntervals:
-      - quantity:
-          unit:
-            id: "UO:0000022"
-            label: "milligram"
-          value: 6.0
-        scheduleFrequency:
-          id: "NCIT:C125004"
-          label: "Once Daily"
-        interval:
-          start: "2020-03-20T00:00:00Z"
-          end: "2020-03-30T00:00:00Z"
-  - procedure:
-      code:
-        id: "NCIT:C116648"
-        label: "Tracheal Intubation"
-      performed:
-        timestamp: "2020-03-22T00:00:00Z"
-  - treatment:
-      agent:
-        id: "NCIT:C722"
-        label: "Oxygen"
-      routeOfAdministration:
-        id: "NCIT:C50254"
-        label: "Positive end Expiratory Pressure Valve Device"
-      doseIntervals:
-      - quantity:
-          unit:
-            id: "NCIT:C91060"
-            label: "Centimeters of Water"
-          value: 14.0
-        scheduleFrequency:
-          id: "PATO:0000689"
-          label: "continuous"
-        interval:
-          start: "2020-03-22T00:00:00Z"
-          end: "2020-03-28T00:00:00Z"
-  - treatment:
-      agent:
-        id: "NCIT:C84217"
-        label: "Tocilizumab"
-      doseIntervals:
-      - quantity:
-          unit:
-            id: "NCIT:C124458"
-            label: "Milligram per Kilogram per Dose"
-          value: 4.0
-        scheduleFrequency:
-          id: "NCIT:C64529"
-          label: "Every Four Weeks"
-        interval:
-          start: "2020-03-24T00:00:00Z"
-          end: "2020-03-28T00:00:00Z"
-  metaData:
-    created: "2021-08-17T00:00:00Z"
-    createdBy: "anonymous biocurator"
-    resources:
-    - id: "ncit"
-      name: "NCI Thesaurus"
-      url: "http://purl.obolibrary.org/obo/ncit.owl"
-      version: "2019-11-26"
-      namespacePrefix: "NCIT"
-      iriPrefix: "http://purl.obolibrary.org/obo/NCIT_"
-    - id: "mondo"
-      name: "Mondo Disease Ontology"
-      url: "http://purl.obolibrary.org/obo/mondo.obo"
-      version: "2021-11-26"
-      namespacePrefix: "MONDO"
-      iriPrefix: "http://purl.obolibrary.org/obo/MONDO_"
-    phenopacketSchemaVersion: "2.0"
-    externalReferences:
-    - id: "DOI:10.1016/j.jaccas.2020.04.001"
-      reference: "PMID:32292915"
-      description: "The Imperfect Cytokine Storm: Severe COVID-19 With ARDS in a Patient\
-        \ on Durable LVAD Support"
+  sex: "MALE"
+phenotypicFeatures:
+- type:
+    id: "HP:0001945"
+    label: "Fever "
+  onset:
+    timestamp: "2021-02-01T05:00:00Z"
+- type:
+    id: "HP:0030157"
+    label: "Flank pain"
+  onset:
+    timestamp: "2021-02-01T05:00:00Z"
+- type:
+    id: "HP:0000790"
+    label: "Hematuria"
+  onset:
+    timestamp: "2021-02-01T05:00:00Z"
+- type:
+    id: "HP:0012625"
+    label: "Stage 3 chronic kidney disease"
+  onset:
+    timestamp: "2021-02-01T05:00:00Z"
+- type:
+    id: "HP:0003326"
+    label: "Myalgia"
+  onset:
+    interval:
+      start: "2020-03-18T00:00:00Z"
+      end: "2020-03-20T00:00:00Z"
+- type:
+    id: "HP:0002014"
+    label: "Diarrhea"
+  onset:
+    interval:
+      start: "2020-03-18T00:00:00Z"
+      end: "2020-03-20T00:00:00Z"
+- type:
+    id: "HP:0002094"
+    label: "Dyspnea"
+  onset:
+    interval:
+      start: "2020-03-18T00:00:00Z"
+      end: "2020-03-20T00:00:00Z"
+- type:
+    id: "HP:0033677"
+    label: "Acute respiratory distress syndrome"
+  onset:
+    timestamp: "2020-03-20T00:00:00Z"
+measurements:
+- assay:
+    id: "LOINC:26474-7"
+    label: "Lymphocytes [#/volume] in Blood"
+  value:
+    quantity:
+      unit:
+        id: "NCIT:C67245"
+        label: "Thousand Cells"
+      value: 1.4
+  timeObserved:
+    interval:
+      start: "2019-09-01T00:00:00Z"
+      end: "2020-03-01T00:00:00Z"
+- assay:
+    id: "LOINC:26474-7"
+    label: "Lymphocytes [#/volume] in Blood"
+  value:
+    quantity:
+      unit:
+        id: "NCIT:C67245"
+        label: "Thousand Cells"
+      value: 0.7
+  timeObserved:
+    timestamp: "2020-03-20T00:00:00Z"
+diseases:
+- term:
+    id: "MONDO:0005015"
+    label: "diabetes mellitus"
+  excluded: true
+- term:
+    id: "MONDO:0004994"
+    label: "cardiomyopathy"
+- term:
+    id: "MONDO:0100096"
+    label: "COVID-19"
+  onset:
+    timestamp: "2020-03-17T00:00:00Z"
+medicalActions:
+- procedure:
+    code:
+      id: "NCIT:C80473"
+      label: "Left Ventricular Assist Device"
+    performed:
+      timestamp: "2016-01-01T00:00:00Z"
+- treatment:
+    agent:
+      id: "NCIT:C722"
+      label: "Oxygen"
+    routeOfAdministration:
+      id: "NCIT:C38284"
+      label: "Nasal Route of Administration"
+    doseIntervals:
+    - quantity:
+        unit:
+          id: "NCIT:C67388"
+          label: "Liter per Minute"
+        value: 2.0
+      scheduleFrequency:
+        id: "PATO:0000689"
+        label: "continuous"
+      interval:
+        start: "2021-02-01T18:58:43Z"
+        end: "2021-02-02T08:22:42Z"
+    - quantity:
+        unit:
+          id: "NCIT:C67388"
+          label: "Liter per Minute"
+        value: 50.0
+      scheduleFrequency:
+        id: "PATO:0000689"
+        label: "continuous"
+      interval:
+        start: "2021-02-02T08:22:42Z"
+        end: "2021-02-02T12:22:42Z"
+- treatment:
+    agent:
+      id: "CHEBI:41879"
+      label: "dexamethasone"
+    doseIntervals:
+    - quantity:
+        unit:
+          id: "UO:0000022"
+          label: "milligram"
+        value: 6.0
+      scheduleFrequency:
+        id: "NCIT:C125004"
+        label: "Once Daily"
+      interval:
+        start: "2020-03-20T00:00:00Z"
+        end: "2020-03-30T00:00:00Z"
+- procedure:
+    code:
+      id: "NCIT:C116648"
+      label: "Tracheal Intubation"
+    performed:
+      timestamp: "2020-03-22T00:00:00Z"
+- treatment:
+    agent:
+      id: "NCIT:C722"
+      label: "Oxygen"
+    routeOfAdministration:
+      id: "NCIT:C50254"
+      label: "Positive end Expiratory Pressure Valve Device"
+    doseIntervals:
+    - quantity:
+        unit:
+          id: "NCIT:C91060"
+          label: "Centimeters of Water"
+        value: 14.0
+      scheduleFrequency:
+        id: "PATO:0000689"
+        label: "continuous"
+      interval:
+        start: "2020-03-22T00:00:00Z"
+        end: "2020-03-28T00:00:00Z"
+- treatment:
+    agent:
+      id: "NCIT:C84217"
+      label: "Tocilizumab"
+    doseIntervals:
+    - quantity:
+        unit:
+          id: "NCIT:C124458"
+          label: "Milligram per Kilogram per Dose"
+        value: 4.0
+      scheduleFrequency:
+        id: "NCIT:C64529"
+        label: "Every Four Weeks"
+      interval:
+        start: "2020-03-24T00:00:00Z"
+        end: "2020-03-28T00:00:00Z"
+metaData:
+  created: "2021-08-17T00:00:00Z"
+  createdBy: "anonymous biocurator"
+  resources:
+  - id: "ncit"
+    name: "NCI Thesaurus"
+    url: "http://purl.obolibrary.org/obo/ncit.owl"
+    version: "2019-11-26"
+    namespacePrefix: "NCIT"
+    iriPrefix: "http://purl.obolibrary.org/obo/NCIT_"
+  - id: "mondo"
+    name: "Mondo Disease Ontology"
+    url: "http://purl.obolibrary.org/obo/mondo.obo"
+    version: "2021-11-26"
+    namespacePrefix: "MONDO"
+    iriPrefix: "http://purl.obolibrary.org/obo/MONDO_"
+  phenopacketSchemaVersion: "2.0"
+  externalReferences:
+  - id: "DOI:10.1016/j.jaccas.2020.04.001"
+    reference: "PMID:32292915"
+    description: "The Imperfect Cytokine Storm: Severe COVID-19 With ARDS in a Patient\
+      \ on Durable LVAD Support"

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.json
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.json
@@ -1,0 +1,109 @@
+{
+  "id": "family.1",
+  "proband": {
+    "id": "phenopacket.id.1",
+    "subject": {
+      "id": "son.1",
+      "timeAtLastEncounter": {
+        "age": {
+          "iso8601duration": "P10Y2M4D"
+        }
+      },
+      "sex": "MALE",
+      "karyotypicSex": "UNKNOWN_KARYOTYPE"
+    },
+    "phenotypicFeatures": [{
+      "type": {
+        "id": "HP:0000407",
+        "label": "Sensorineural hearing impairment "
+      },
+      "excluded": false,
+      "onset": {
+        "ontologyClass": {
+          "id": "HP:0003577",
+          "label": "Congenital onset"
+        }
+      }
+    }],
+    "metaData": {
+      "created": "2022-04-17T10:35:00Z",
+      "createdBy": "biocurator",
+      "resources": [{
+        "id": "hp",
+        "name": "human phenotype ontology",
+        "url": "http://purl.obolibrary.org/obo/hp.owl",
+        "version": "2022-04-15",
+        "namespacePrefix": "HP",
+        "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
+      }],
+      "phenopacketSchemaVersion": "2.0.0"
+    }
+  },
+  "pedigree": {
+    "persons": [{
+      "familyId": "family.1",
+      "individualId": "father.1",
+      "paternalId": "0",
+      "maternalId": "0",
+      "sex": "MALE",
+      "affectedStatus": "UNAFFECTED"
+    }, {
+      "familyId": "family.1",
+      "individualId": "mother.1",
+      "paternalId": "0",
+      "maternalId": "0",
+      "sex": "FEMALE",
+      "affectedStatus": "UNAFFECTED"
+    }, {
+      "familyId": "family.1",
+      "individualId": "daughter.1",
+      "paternalId": "father.1",
+      "maternalId": "mother.1",
+      "sex": "FEMALE",
+      "affectedStatus": "UNAFFECTED"
+    }, {
+      "familyId": "family.1",
+      "individualId": "son.1",
+      "paternalId": "father.1",
+      "maternalId": "mother.1",
+      "sex": "MALE",
+      "affectedStatus": "AFFECTED"
+    }, {
+      "familyId": "family.1",
+      "individualId": "daughter.2",
+      "paternalId": "father.1",
+      "maternalId": "mother.1",
+      "sex": "FEMALE",
+      "affectedStatus": "UNAFFECTED"
+    }]
+  },
+  "files": [{
+    "uri": "/data/samples/vcf/example_000001215.vcf.gz",
+    "individualToFileIdentifiers": {
+      "father.1": "sample.1",
+      "mother.1": "sample.2",
+      "daughter.1": "sample.3",
+      "son.1": "sample.4",
+      "daughter.2": "sample.5"
+    },
+    "fileAttributes": {
+      "genomeAssembly": "GRCh38",
+      "fileFormat": "VCF",
+      "description": "multi-sample VCF file for family.1"
+    }
+  }],
+  "metaData": {
+    "created": "2022-04-17T10:35:00Z",
+    "createdBy": "biocurator",
+    "resources": [{
+      "id": "hp",
+      "name": "human phenotype ontology",
+      "url": "http://purl.obolibrary.org/obo/hp.owl",
+      "version": "2022-06-11",
+      "namespacePrefix": "HP",
+      "iriPrefix": "http://purl.obolibrary.org/obo/HP_"
+    }],
+    "phenopacketSchemaVersion": "2.0.0"
+  },
+  "consanguinousParents": false
+}

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.yml
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.yml
@@ -1,0 +1,86 @@
+id: "family.1"
+proband:
+  id: "phenopacket.id.1"
+  subject:
+    id: "son.1"
+    timeAtLastEncounter:
+      age:
+        iso8601duration: "P10Y2M4D"
+    sex: "MALE"
+    karyotypicSex: "UNKNOWN_KARYOTYPE"
+  phenotypicFeatures:
+  - type:
+      id: "HP:0000407"
+      label: "Sensorineural hearing impairment "
+    excluded: false
+    onset:
+      ontologyClass:
+        id: "HP:0003577"
+        label: "Congenital onset"
+  metaData:
+    created: "2022-04-17T10:35:00Z"
+    createdBy: "biocurator"
+    resources:
+    - id: "hp"
+      name: "human phenotype ontology"
+      url: "http://purl.obolibrary.org/obo/hp.owl"
+      version: "2022-04-15"
+      namespacePrefix: "HP"
+      iriPrefix: "http://purl.obolibrary.org/obo/HP_"
+    phenopacketSchemaVersion: "2.0.0"
+pedigree:
+  persons:
+  - familyId: "family.1"
+    individualId: "father.1"
+    paternalId: "0"
+    maternalId: "0"
+    sex: "MALE"
+    affectedStatus: "UNAFFECTED"
+  - familyId: "family.1"
+    individualId: "mother.1"
+    paternalId: "0"
+    maternalId: "0"
+    sex: "FEMALE"
+    affectedStatus: "UNAFFECTED"
+  - familyId: "family.1"
+    individualId: "daughter.1"
+    paternalId: "father.1"
+    maternalId: "mother.1"
+    sex: "FEMALE"
+    affectedStatus: "UNAFFECTED"
+  - familyId: "family.1"
+    individualId: "son.1"
+    paternalId: "father.1"
+    maternalId: "mother.1"
+    sex: "MALE"
+    affectedStatus: "AFFECTED"
+  - familyId: "family.1"
+    individualId: "daughter.2"
+    paternalId: "father.1"
+    maternalId: "mother.1"
+    sex: "FEMALE"
+    affectedStatus: "UNAFFECTED"
+files:
+- uri: "/data/samples/vcf/example_000001215.vcf.gz"
+  individualToFileIdentifiers:
+    father.1: "sample.1"
+    mother.1: "sample.2"
+    daughter.1: "sample.3"
+    son.1: "sample.4"
+    daughter.2: "sample.5"
+  fileAttributes:
+    genomeAssembly: "GRCh38"
+    fileFormat: "VCF"
+    description: "multi-sample VCF file for family.1"
+metaData:
+  created: "2022-04-17T10:35:00Z"
+  createdBy: "biocurator"
+  resources:
+  - id: "hp"
+    name: "human phenotype ontology"
+    url: "http://purl.obolibrary.org/obo/hp.owl"
+    version: "2022-06-11"
+    namespacePrefix: "HP"
+    iriPrefix: "http://purl.obolibrary.org/obo/HP_"
+  phenopacketSchemaVersion: "2.0.0"
+consanguinousParents: false

--- a/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.yml
+++ b/phenopacket-tools-util/src/test/resources/org/phenopackets/phenopackettools/util/format/family.v2.yml
@@ -1,3 +1,5 @@
+---
+# This is a meaningless comment in an example family.
 id: "family.1"
 proband:
   id: "phenopacket.id.1"

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/HpoPhenotypeValidators.java
@@ -31,7 +31,7 @@ public class HpoPhenotypeValidators {
      * @param hpo HPO ontology
      * @deprecated use {@link Primary#phenopacketHpoPhenotypeValidator(Ontology)} instead
      */
-    // TODO - remove prior v1
+    // REMOVE(v1.0.0)
     @Deprecated(forRemoval = true)
     public static PhenopacketValidator<PhenopacketOrBuilder> phenopacketHpoPhenotypeValidator(Ontology hpo) {
         return Primary.phenopacketHpoPhenotypeValidator(hpo);
@@ -43,7 +43,7 @@ public class HpoPhenotypeValidators {
      * @param hpo HPO ontology
      * @deprecated use {@link Primary#familyHpoPhenotypeValidator(Ontology)} instead
      */
-    // TODO - remove prior v1
+    // REMOVE(v1.0.0)
     @Deprecated(forRemoval = true)
     public static PhenopacketValidator<FamilyOrBuilder> familyHpoPhenotypeValidator(Ontology hpo) {
         return Primary.familyHpoPhenotypeValidator(hpo);
@@ -56,7 +56,7 @@ public class HpoPhenotypeValidators {
      * @param hpo HPO ontology
      * @deprecated use {@link Primary#cohortHpoPhenotypeValidator(Ontology)} instead
      */
-    // TODO - remove prior v1
+    // REMOVE(v1.0.0)
     @Deprecated(forRemoval = true)
     public static PhenopacketValidator<CohortOrBuilder> cohortHpoPhenotypeValidator(Ontology hpo) {
         return Primary.cohortHpoPhenotypeValidator(hpo);

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/BaseHpoValidator.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/phenotype/base/BaseHpoValidator.java
@@ -14,8 +14,7 @@ public abstract class BaseHpoValidator<T extends MessageOrBuilder> implements Ph
 
     protected BaseHpoValidator(Ontology hpo) {
         this.hpo = Objects.requireNonNull(hpo);
-        // TODO - can be replaced by this.hpo.version() in the most recent phenol versions.
-        this.hpoVersion = this.hpo.getMetaInfo().getOrDefault("data-version", "HPO");
+        this.hpoVersion = hpo.version().orElse("UNKNOWN");
     }
 
     protected static String summarizePhenopacketAndIndividualId(PhenopacketOrBuilder phenopacket) {

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/PrimaryHpoPhenotypeValidatorTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/phenotype/PrimaryHpoPhenotypeValidatorTest.java
@@ -85,7 +85,7 @@ public class PrimaryHpoPhenotypeValidatorTest {
             ValidationResult result = results.get(0);
             assertThat(result.level(), equalTo(ValidationLevel.ERROR));
             assertThat(result.category(), equalTo("Invalid TermId"));
-            assertThat(result.message(), equalTo("HP:0001182 in proband A not found in http://purl.obolibrary.org/obo/hp/releases/2021-06-08/hp.json"));
+            assertThat(result.message(), equalTo("HP:0001182 in proband A not found in 2021-06-08"));
         }
 
         @Test

--- a/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunner.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/org/phenopackets/phenopackettools/validator/jsonschema/JsonSchemaValidationWorkflowRunner.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.MessageOrBuilder;
 import org.phenopackets.phenopackettools.util.format.FormatSniffer;
 import org.phenopackets.phenopackettools.core.PhenopacketFormat;
-import org.phenopackets.phenopackettools.util.format.FormatSniffException;
 import org.phenopackets.phenopackettools.validator.core.*;
 import org.phenopackets.phenopackettools.validator.jsonschema.impl.JsonSchemaValidator;
 import org.phenopackets.schema.v2.CohortOrBuilder;
@@ -159,15 +158,11 @@ public class JsonSchemaValidationWorkflowRunner<T extends MessageOrBuilder> impl
     }
 
     private String parseToString(byte[] payload) throws ConversionException {
-        try {
-            PhenopacketFormat format = FormatSniffer.sniff(payload);
-            return switch (format) {
-                case JSON, YAML -> new String(payload);
-                case PROTOBUF -> converter.toJson(payload);
-            };
-        } catch (FormatSniffException e) {
-            throw new ConversionException(e);
-        }
+        PhenopacketFormat format = FormatSniffer.sniff(payload);
+        return switch (format) {
+            case JSON, YAML -> new String(payload);
+            case PROTOBUF -> converter.toJson(payload);
+        };
     }
 
     /**


### PR DESCRIPTION
Improve format sniffing and implement element sniffing for JSON and YAML.

The PR adds a bug fix for the simple format sniffing. The format sniffing algorithm first checks if the input looks like YAML or JSON file and falls back to Protobuf if not.

The element sniffing works for JSON and YAML formats. In JSON, the algorithm determines the element using discriminatory top-level fields; the field names that are unique to `Phenopacket` (e.g. `subject`), `Family` (e.g. `pedigree`) and `Cohort` (e.g. `members`). An exception is thrown if the available content does not contain a discriminatory field or in presence of fields from different top-level components.

Element sniffing does not work for Protobuf at the moment.