### PR TITLE
Add showcase of apps that use phenopacket-tools.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ from our `GitHub repository <https://github.com/phenopackets/phenopacket-tools>`
 The following sections describe phenopacket-tools library and CLI application.
 We start with :ref:`rsttutorial` to provide a quick overview of the CLI functionality.
 We follow with comprehensive description of the :ref:`rstcli`.
-The rest of the documentation offers an in-depth user guide for using the library functionality
+The rest of the documentation offers an in-depth user guide and a showcase of the library functionality
 in JVM-based applications.
 
 .. toctree::
@@ -47,6 +47,7 @@ in JVM-based applications.
    converting
    validation
    examples
+   showcase
 
 
 .. figure:: https://onlinelibrary.wiley.com/cms/asset/1cc0a141-da65-45a3-b7b0-6316b7b02069/ggn2202200016-fig-0002-m.jpg

--- a/docs/showcase.rst
+++ b/docs/showcase.rst
@@ -1,0 +1,31 @@
+.. _rstshowcase:
+
+===================================================
+Showcase of applications that use phenopacket-tools
+===================================================
+
+We present a list of tools and applications that use phenopacket-tools to read, build, or Q/C phenopackets.
+
+
+We present a list of tools and applications that use phenopacket-tools to read, build, or Q/C phenopackets and other components of the Phenopacket Schema.
+
+* `LIRICAL <https://www.cell.com/ajhg/fulltext/S0002-9297(20)30230-5>`_ runs phenotype-driven prioritization of Mendelian diseases on a Phenopacket.
+
+   LIRICAL uses `phenopacket-tools-io` to `read phenopackets <https://github.com/TheJacksonLaboratory/LIRICAL/blob/f516e463986880285436fd93540da3c6b7510fb7/lirical-io/src/main/java/org/monarchinitiative/lirical/io/analysis/PhenopacketImportUtil.java#L18>`_.
+
+..
+   TODO
+   and `phenopacket-tools-validator-core` for input `quality control <>`_.
+
+* `SvAnna <https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-022-01046-6>`_ applies phenotype-driven prioritization on coding and regulatory structural variants in long-read genome sequencing.
+
+   SvAnna uses `phenopacket-tools-io` for `reading input <https://github.com/TheJacksonLaboratory/SvAnna/blob/master/svanna-cli/src/main/java/org/monarchinitiative/svanna/cli/cmd/PhenopacketAnalysisDataUtil.java>`_
+   formatted as a phenopacket.
+
+* `HPO Case Annotator <https://github.com/monarch-initiative/HpoCaseAnnotator>`_ is a GUI application for biocuration of case reports, cohorts and families.
+
+   Hpo Case Annotator uses `phenopacket-tools-builder` for `mapping the entered data into Phenopacket Schema <https://github.com/monarch-initiative/HpoCaseAnnotator/tree/development/hpo-case-annotator-export/src/main/java/org/monarchinitiative/hpo_case_annotator/export/ppv2>`_
+   format and `phenopacket-tools-io` for `storing phenopackets <https://github.com/monarch-initiative/HpoCaseAnnotator/blob/509480ff78af3996bdacb6513feedb1f18e39c17/hpo-case-annotator-app/src/main/java/org/monarchinitiative/hpo_case_annotator/app/controller/MainController.java#L727>`_ into JSON files.
+
+
+Please let us know about your application by submitting a request on our `issue tracker <https://github.com/phenopackets/phenopacket-tools/issues>`_.


### PR DESCRIPTION
Add a documentation section that shows a list of apps which use *phenopacket-tools* as a dependency.