### PR TITLE
Improve handling of the default elements when converting from v1 to v2.

### DIFF
--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2Converter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2Converter.java
@@ -13,6 +13,10 @@ import org.phenopackets.schema.v2.Phenopacket;
  * {@link org.phenopackets.schema.v2.core.GenomicInterpretation.InterpretationStatus#CAUSATIVE}. For this to work,
  * there must be exactly one {@link org.phenopackets.schema.v1.core.Disease} in the phenopacket, otherwise
  * a {@link org.phenopackets.phenopackettools.core.PhenopacketToolsRuntimeException} is thrown.
+ * <p>
+ * Note, it is technically possible to convert an empty v1 phenopacket, family, or cohort message. In that case,
+ * the returned instance
+ * will equal to protobuf default instance (e.g. {@link org.phenopackets.schema.v1.Phenopacket#getDefaultInstance()}).
  */
 public interface V1ToV2Converter {
 

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverter.java
@@ -3,19 +3,38 @@ package org.phenopackets.phenopackettools.converter.converters.v2;
 import org.phenopackets.schema.v2.core.Age;
 import org.phenopackets.schema.v2.core.AgeRange;
 
-public class AgeConverter {
+import java.util.Optional;
+
+class AgeConverter {
 
     private AgeConverter() {
     }
 
-    public static Age toAge(org.phenopackets.schema.v1.core.Age v1Age) {
-        return Age.newBuilder().setIso8601Duration(v1Age.getAge()).build();
+    static Optional<Age> toAge(org.phenopackets.schema.v1.core.Age v1Age) {
+        if (v1Age.equals(org.phenopackets.schema.v1.core.Age.getDefaultInstance()) || v1Age.getAge().isEmpty())
+            return Optional.empty();
+        else {
+            return Optional.of(Age.newBuilder()
+                    .setIso8601Duration(v1Age.getAge())
+                    .build());
+        }
     }
 
-    public static AgeRange toAgeRange(org.phenopackets.schema.v1.core.AgeRange v1AgeRange) {
-        return AgeRange.newBuilder()
-                .setStart(toAge(v1AgeRange.getStart()))
-                .setEnd(toAge(v1AgeRange.getEnd()))
-                .build();
+    static Optional<AgeRange> toAgeRange(org.phenopackets.schema.v1.core.AgeRange v1AgeRange) {
+        if (v1AgeRange.equals(org.phenopackets.schema.v1.core.AgeRange.getDefaultInstance()))
+            return Optional.empty();
+
+        Optional<Age> start = toAge(v1AgeRange.getStart());
+        Optional<Age> end = toAge(v1AgeRange.getEnd());
+
+        if (start.isEmpty() && end.isEmpty())
+            return Optional.empty();
+        else
+            return Optional.of(
+                    AgeRange.newBuilder()
+                            .setStart(start.orElse(Age.getDefaultInstance()))
+                            .setEnd(end.orElse(Age.getDefaultInstance()))
+                            .build()
+            );
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/BiosampleConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/BiosampleConverter.java
@@ -1,21 +1,17 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
-import org.phenopackets.schema.v2.core.Biosample;
-import org.phenopackets.schema.v2.core.OntologyClass;
-import org.phenopackets.schema.v2.core.TimeElement;
+import org.phenopackets.phenopackettools.builder.builders.OntologyClassBuilder;
+import org.phenopackets.schema.v2.core.*;
 
 import java.util.List;
+import java.util.Optional;
 
-import static org.phenopackets.phenopackettools.converter.converters.v2.FileConverter.toFiles;
-import static org.phenopackets.phenopackettools.converter.converters.v2.OntologyClassConverter.toOntologyClass;
-import static org.phenopackets.phenopackettools.converter.converters.v2.OntologyClassConverter.toOntologyClassList;
 import static org.phenopackets.phenopackettools.converter.converters.v2.PhenotypicFeatureConverter.*;
-import static org.phenopackets.phenopackettools.converter.converters.v2.ProcedureConverter.toProcedure;
 
 public class BiosampleConverter {
 
-    private static final OntologyClass referenceSample = OntologyClass.newBuilder().setId("EFO:0009654").setLabel("reference sample").build();
-    private static final  OntologyClass abnormalSample = OntologyClass.newBuilder().setId("EFO:0009655").setLabel("abnormal sample").build();
+    private static final OntologyClass referenceSample = OntologyClassBuilder.ontologyClass("EFO:0009654", "reference sample");
+    private static final OntologyClass abnormalSample = OntologyClassBuilder.ontologyClass("EFO:0009655", "abnormal sample");
 
     private BiosampleConverter() {
     }
@@ -23,58 +19,120 @@ public class BiosampleConverter {
     public static List<Biosample> toBiosamples(List<org.phenopackets.schema.v1.core.Biosample> biosamples) {
         return biosamples.stream()
                 .map(BiosampleConverter::toBiosample)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    public static Biosample toBiosample(org.phenopackets.schema.v1.core.Biosample biosample) {
-        Biosample.Builder builder = Biosample.newBuilder();
-        if (biosample.hasSampledTissue()) {
-            builder.setSampledTissue(toOntologyClass(biosample.getSampledTissue()));
-        }
-        if (biosample.hasTaxonomy()) {
-            builder.setTaxonomy(toOntologyClass(biosample.getTaxonomy()));
-        }
-        if (biosample.hasAgeOfIndividualAtCollection() || biosample.hasAgeRangeOfIndividualAtCollection()) {
-            builder.setTimeOfCollection(toTimeOfCollection(biosample));
-        }
-        if (biosample.hasHistologicalDiagnosis()) {
-            builder.setHistologicalDiagnosis(toOntologyClass(biosample.getHistologicalDiagnosis()));
-        }
-        if (biosample.hasTumorProgression()) {
-            builder.setTumorProgression(toOntologyClass(biosample.getTumorProgression()));
+    public static Optional<Biosample> toBiosample(org.phenopackets.schema.v1.core.Biosample biosample) {
+        if (biosample.equals(org.phenopackets.schema.v1.core.Biosample.getDefaultInstance()))
+            return Optional.empty();
 
+        boolean isDefault = true;
+        Biosample.Builder builder = Biosample.newBuilder();
+
+        String id = biosample.getId();
+        if (!id.isEmpty()) {
+            isDefault = false;
+            builder.setId(id);
         }
-        if (biosample.hasTumorGrade()) {
-            builder.setTumorGrade(toOntologyClass(biosample.getTumorGrade()));
+
+        String individualId = biosample.getIndividualId();
+        if (!individualId.isEmpty()) {
+            isDefault = false;
+            builder.setIndividualId(individualId);
         }
-        if (biosample.hasProcedure()) {
-            builder.setProcedure(toProcedure(biosample.getProcedure()));
+
+        String description = biosample.getDescription();
+        if (!description.isEmpty()) {
+            isDefault = false;
+            builder.setDescription(description);
         }
+
+        Optional<OntologyClass> sampledTissue = OntologyClassConverter.toOntologyClass(biosample.getSampledTissue());
+        if (sampledTissue.isPresent()) {
+            isDefault = false;
+            builder.setSampledTissue(sampledTissue.get());
+        }
+
+        List<PhenotypicFeature> phenotypicFeatures = toPhenotypicFeatures(biosample.getPhenotypicFeaturesList());
+        if (!phenotypicFeatures.isEmpty()) {
+            isDefault = false;
+            builder.addAllPhenotypicFeatures(phenotypicFeatures);
+        }
+
+        Optional<OntologyClass> taxonomy = OntologyClassConverter.toOntologyClass(biosample.getTaxonomy());
+        if (taxonomy.isPresent()) {
+            isDefault = false;
+            builder.setTaxonomy(taxonomy.get());
+        }
+
+        Optional<TimeElement> timeOfCollection = toTimeOfCollection(biosample);
+        if (timeOfCollection.isPresent()) {
+            isDefault = false;
+            builder.setTimeOfCollection(timeOfCollection.get());
+        }
+
+        Optional<OntologyClass> histologicalDiagnosis = OntologyClassConverter.toOntologyClass(biosample.getHistologicalDiagnosis());
+        if (histologicalDiagnosis.isPresent()) {
+            isDefault = false;
+            builder.setHistologicalDiagnosis(histologicalDiagnosis.get());
+        }
+
+        Optional<OntologyClass> tumorProgression = OntologyClassConverter.toOntologyClass(biosample.getTumorProgression());
+        if (tumorProgression.isPresent()) {
+            isDefault = false;
+            builder.setTumorProgression(tumorProgression.get());
+        }
+
+        Optional<OntologyClass> tumorGrade = OntologyClassConverter.toOntologyClass(biosample.getTumorGrade());
+        if (tumorGrade.isPresent()) {
+            isDefault = false;
+            builder.setTumorGrade(tumorGrade.get());
+        }
+
+        List<OntologyClass> diagnosticMarkers = OntologyClassConverter.toOntologyClassList(biosample.getDiagnosticMarkersList());
+        if (!diagnosticMarkers.isEmpty()) {
+            isDefault = false;
+            builder.addAllDiagnosticMarkers(diagnosticMarkers);
+        }
+
+        Optional<Procedure> procedure = ProcedureConverter.toProcedure(biosample.getProcedure());
+        if (procedure.isPresent()) {
+            isDefault = false;
+            builder.setProcedure(procedure.get());
+        }
+
+        List<File> files = FileConverter.toFiles(biosample.getHtsFilesList());
+        if (!files.isEmpty()) {
+            isDefault = false;
+            builder.addAllFiles(files);
+        }
+
         if (biosample.getVariantsCount() != 0) {
             // TODO: create an interpretation along with any genes
         }
-        if (biosample.getIsControlSample()) {
-            builder.setMaterialSample(referenceSample);
-        } else if (biosample.hasTumorProgression() || biosample.hasTumorGrade()) {
-            builder.setMaterialSample(abnormalSample);
-        }
 
-        return builder
-                .setId(biosample.getId())
-                .setIndividualId(biosample.getIndividualId())
-                .setDescription(biosample.getDescription())
-                .addAllPhenotypicFeatures(toPhenotypicFeatures(biosample.getPhenotypicFeaturesList()))
-                .addAllDiagnosticMarkers(toOntologyClassList(biosample.getDiagnosticMarkersList()))
-                .addAllFiles(toFiles(biosample.getHtsFilesList()))
-                .build();
+        if (biosample.getIsControlSample())
+            // (non)-defaultness does not apply here
+            builder.setMaterialSample(referenceSample);
+        else if (tumorProgression.isPresent() || tumorGrade.isPresent())
+            builder.setMaterialSample(abnormalSample);
+
+
+        if (isDefault)
+            return Optional.empty();
+        else
+            return Optional.of(builder.build());
     }
 
-    private static TimeElement toTimeOfCollection(org.phenopackets.schema.v1.core.Biosample biosample) {
+    private static Optional<TimeElement> toTimeOfCollection(org.phenopackets.schema.v1.core.Biosample biosample) {
         if (biosample.hasAgeOfIndividualAtCollection()) {
-            return TimeElement.newBuilder().setAge(AgeConverter.toAge(biosample.getAgeOfIndividualAtCollection())).build();
+            return AgeConverter.toAge(biosample.getAgeOfIndividualAtCollection())
+                    .map(age -> TimeElement.newBuilder().setAge(age).build());
         } else if (biosample.hasAgeRangeOfIndividualAtCollection()) {
-            return TimeElement.newBuilder().setAgeRange(AgeConverter.toAgeRange(biosample.getAgeRangeOfIndividualAtCollection())).build();
+            return AgeConverter.toAgeRange(biosample.getAgeRangeOfIndividualAtCollection())
+                    .map(ageRange -> TimeElement.newBuilder().setAgeRange(ageRange).build());
         }
-        return TimeElement.getDefaultInstance();
+        return Optional.empty();
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/DiseaseConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/DiseaseConverter.java
@@ -1,13 +1,11 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
 import org.phenopackets.schema.v2.core.Disease;
+import org.phenopackets.schema.v2.core.OntologyClass;
 import org.phenopackets.schema.v2.core.TimeElement;
 
 import java.util.List;
-
-import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAge;
-import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAgeRange;
-import static org.phenopackets.phenopackettools.converter.converters.v2.OntologyClassConverter.*;
+import java.util.Optional;
 
 public class DiseaseConverter {
 
@@ -17,36 +15,41 @@ public class DiseaseConverter {
     public static List<Disease> toDiseases(List<org.phenopackets.schema.v1.core.Disease> diseasesList) {
         return diseasesList.stream()
                 .map(DiseaseConverter::toDisease)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    /**
-     * Convert to V2 disease. Note that not all disease messageas have age of onset information.
-     * If we pass empty lists for the TnmFinding or disease stage, this does not cause the V2 element
-     * to show an empty list in this implementeation
-     * @param v1Disease Disease message from the version 1 Phenopacket Schema
-     * @return Disease message from the version 2 Phenopacket Schema
-     */
-    public static Disease toDisease(org.phenopackets.schema.v1.core.Disease v1Disease) {
-        Disease.Builder builder = Disease.newBuilder()
-                .setTerm(toOntologyClass(v1Disease.getTerm()))
-                .addAllDiseaseStage(toOntologyClassList(v1Disease.getDiseaseStageList()))
-                .addAllClinicalTnmFinding(toOntologyClassList(v1Disease.getTnmFindingList()));
-        if (v1Disease.hasAgeOfOnset() || v1Disease.hasAgeRangeOfOnset() || v1Disease.hasClassOfOnset()) {
-            builder.setOnset(toDiseaseOnset(v1Disease));
-                    // no excluded or resolution in v1
-        }
-        return builder.build();
+    static Optional<Disease> toDisease(org.phenopackets.schema.v1.core.Disease v1Disease) {
+        if (v1Disease.equals(org.phenopackets.schema.v1.core.Disease.getDefaultInstance()))
+            return Optional.empty();
+
+        Optional<OntologyClass> term = OntologyClassConverter.toOntologyClass(v1Disease.getTerm());
+        List<OntologyClass> stages = OntologyClassConverter.toOntologyClassList(v1Disease.getDiseaseStageList());
+        List<OntologyClass> tnm = OntologyClassConverter.toOntologyClassList(v1Disease.getTnmFindingList());
+        Optional<TimeElement> onset = toDiseaseOnset(v1Disease);
+
+        if (term.isEmpty() && stages.isEmpty() && tnm.isEmpty() && onset.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(Disease.newBuilder()
+                .setTerm(term.orElse(OntologyClass.getDefaultInstance()))
+                .addAllDiseaseStage(stages)
+                .addAllClinicalTnmFinding(tnm)
+                .setOnset(onset.orElse(TimeElement.getDefaultInstance()))
+                .build());
     }
 
-    public static TimeElement toDiseaseOnset(org.phenopackets.schema.v1.core.Disease v1Disease) {
-        if (v1Disease.hasClassOfOnset()) {
-            return TimeElement.newBuilder().setOntologyClass(toOntologyClass(v1Disease.getClassOfOnset())).build();
-        } else if (v1Disease.hasAgeOfOnset()) {
-            return TimeElement.newBuilder().setAge(toAge(v1Disease.getAgeOfOnset())).build();
-        } else if (v1Disease.hasAgeRangeOfOnset()) {
-            return TimeElement.newBuilder().setAgeRange(toAgeRange(v1Disease.getAgeRangeOfOnset())).build();
-        }
-        return TimeElement.getDefaultInstance();
+    static Optional<TimeElement> toDiseaseOnset(org.phenopackets.schema.v1.core.Disease v1Disease) {
+        if (v1Disease.hasClassOfOnset())
+            return OntologyClassConverter.toOntologyClass(v1Disease.getClassOfOnset())
+                .map(onsetClass -> TimeElement.newBuilder().setOntologyClass(onsetClass).build());
+        else if (v1Disease.hasAgeOfOnset())
+            return AgeConverter.toAge(v1Disease.getAgeOfOnset())
+                    .map(age -> TimeElement.newBuilder().setAge(age).build());
+        else if (v1Disease.hasAgeRangeOfOnset())
+            return AgeConverter.toAgeRange(v1Disease.getAgeRangeOfOnset())
+                .map(ageRange -> TimeElement.newBuilder().setAgeRange(ageRange).build());
+        else
+            return Optional.empty();
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/EvidenceConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/EvidenceConverter.java
@@ -1,29 +1,40 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
 import org.phenopackets.schema.v2.core.Evidence;
+import org.phenopackets.schema.v2.core.ExternalReference;
+import org.phenopackets.schema.v2.core.OntologyClass;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.ExternalReferenceConverter.toExternalReference;
 import static org.phenopackets.phenopackettools.converter.converters.v2.OntologyClassConverter.toOntologyClass;
 
-public class EvidenceConverter {
+class EvidenceConverter {
 
     private EvidenceConverter() {
     }
 
-    public static List<Evidence> toEvidences(List<org.phenopackets.schema.v1.core.Evidence> evidenceList) {
-        return evidenceList.stream().map(EvidenceConverter::toEvidence).collect(Collectors.toUnmodifiableList());
+    static List<Evidence> toEvidences(List<org.phenopackets.schema.v1.core.Evidence> evidenceList) {
+        return evidenceList.stream()
+                .map(EvidenceConverter::toEvidence)
+                .flatMap(Optional::stream)
+                .toList();
     }
 
-    public static Evidence toEvidence(org.phenopackets.schema.v1.core.Evidence v1Evidence) {
-        if (org.phenopackets.schema.v1.core.Evidence.getDefaultInstance().equals(v1Evidence)) {
-            return Evidence.getDefaultInstance();
-        }
-        return Evidence.newBuilder()
-                .setEvidenceCode(toOntologyClass(v1Evidence.getEvidenceCode()))
-                .setReference(toExternalReference(v1Evidence.getReference()))
-                .build();
+    static Optional<Evidence> toEvidence(org.phenopackets.schema.v1.core.Evidence v1Evidence) {
+        if (v1Evidence.equals(org.phenopackets.schema.v1.core.Evidence.getDefaultInstance()))
+            return Optional.empty();
+
+        Optional<OntologyClass> evidenceCode = toOntologyClass(v1Evidence.getEvidenceCode());
+        Optional<ExternalReference> externalReference = toExternalReference(v1Evidence.getReference());
+
+        if (evidenceCode.isEmpty() && externalReference.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(Evidence.newBuilder()
+                .setEvidenceCode(evidenceCode.orElse(OntologyClass.getDefaultInstance()))
+                .setReference(externalReference.orElse(ExternalReference.getDefaultInstance()))
+                .build());
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ExternalReferenceConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ExternalReferenceConverter.java
@@ -3,25 +3,28 @@ package org.phenopackets.phenopackettools.converter.converters.v2;
 import org.phenopackets.schema.v2.core.ExternalReference;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
-public class ExternalReferenceConverter {
+class ExternalReferenceConverter {
 
     private ExternalReferenceConverter() {
     }
 
-    public static List<ExternalReference> toExternalReferences(List<org.phenopackets.schema.v1.core.ExternalReference> externalReferencesList) {
-        return externalReferencesList.stream().map(ExternalReferenceConverter::toExternalReference).collect(Collectors.toUnmodifiableList());
+    static List<ExternalReference> toExternalReferences(List<org.phenopackets.schema.v1.core.ExternalReference> externalReferencesList) {
+        return externalReferencesList.stream()
+                .map(ExternalReferenceConverter::toExternalReference)
+                .flatMap(Optional::stream)
+                .toList();
     }
 
-    public static ExternalReference toExternalReference(org.phenopackets.schema.v1.core.ExternalReference v1ExternalReference) {
-        if (v1ExternalReference.equals(org.phenopackets.schema.v1.core.ExternalReference.getDefaultInstance())) {
-            return ExternalReference.getDefaultInstance();
-        }
-        return ExternalReference.newBuilder()
+    static Optional<ExternalReference> toExternalReference(org.phenopackets.schema.v1.core.ExternalReference v1ExternalReference) {
+        if (v1ExternalReference.equals(org.phenopackets.schema.v1.core.ExternalReference.getDefaultInstance()))
+            return Optional.empty();
+
+        return Optional.of(ExternalReference.newBuilder()
                 .setId(v1ExternalReference.getId())
                 .setDescription(v1ExternalReference.getDescription())
                 // no v1 field for reference
-                .build();
+                .build());
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/FileConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/FileConverter.java
@@ -4,6 +4,7 @@ import org.phenopackets.schema.v1.core.HtsFile;
 import org.phenopackets.schema.v2.core.File;
 
 import java.util.List;
+import java.util.Optional;
 
 public class FileConverter {
 
@@ -13,17 +14,47 @@ public class FileConverter {
     public static List<File> toFiles(List<HtsFile> htsFilesList) {
         return htsFilesList.stream()
                 .map(FileConverter::toFile)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    public static File toFile(HtsFile htsFile) {
-        return File.newBuilder()
-                .setUri(htsFile.getUri())
-                .putFileAttributes("genomeAssembly", htsFile.getGenomeAssembly())
-                .putFileAttributes("fileFormat", htsFile.getHtsFormat().name().toLowerCase())
-                .putFileAttributes("description", htsFile.getDescription())
-                .putAllIndividualToFileIdentifiers(htsFile.getIndividualToSampleIdentifiersMap())
-                .build();
+    static Optional<File> toFile(HtsFile htsFile) {
+        if (htsFile.equals(HtsFile.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
+        File.Builder builder = File.newBuilder();
+
+        if (!htsFile.getUri().isEmpty()) {
+            isDefault = false;
+            builder.setUri(htsFile.getUri());
+        }
+
+        String assembly = htsFile.getGenomeAssembly();
+        if (!assembly.isEmpty()) {
+            isDefault = false;
+            builder.putFileAttributes("genomeAssembly", assembly);
+        }
+
+        HtsFile.HtsFormat htsFormat = htsFile.getHtsFormat();
+        if (!htsFormat.equals(HtsFile.HtsFormat.UNKNOWN) && !htsFormat.equals(HtsFile.HtsFormat.UNRECOGNIZED)) {
+            isDefault = false;
+            builder.putFileAttributes("fileFormat", htsFormat.name().toLowerCase());
+        }
+
+        if (!htsFile.getDescription().isEmpty()) {
+            isDefault = false;
+            builder.putFileAttributes("description", htsFile.getDescription());
+        }
+
+        if (htsFile.getIndividualToSampleIdentifiersCount() != 0) {
+            isDefault = false;
+            builder.putAllIndividualToFileIdentifiers(htsFile.getIndividualToSampleIdentifiersMap());
+        }
+
+        return isDefault
+                ? Optional.empty()
+                : Optional.of(builder.build());
     }
 
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/IndividualConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/IndividualConverter.java
@@ -1,9 +1,9 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
-import org.phenopackets.schema.v2.core.Individual;
-import org.phenopackets.schema.v2.core.KaryotypicSex;
-import org.phenopackets.schema.v2.core.Sex;
-import org.phenopackets.schema.v2.core.TimeElement;
+import com.google.protobuf.Timestamp;
+import org.phenopackets.schema.v2.core.*;
+
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAge;
 import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAgeRange;
@@ -14,20 +14,62 @@ public class IndividualConverter {
     private IndividualConverter() {
     }
 
-    public static Individual toIndividual(org.phenopackets.schema.v1.core.Individual v1Indvidual) {
-        return Individual.newBuilder()
-                .setId(v1Indvidual.getId())
-                .addAllAlternateIds(v1Indvidual.getAlternateIdsList())
-                .setDateOfBirth(v1Indvidual.getDateOfBirth())
-                .setSex(toSex(v1Indvidual.getSex()))
-                .setKaryotypicSex(toKaryotypicSex(v1Indvidual.getKaryotypicSex()))
-                .setTaxonomy(toOntologyClass(v1Indvidual.getTaxonomy()))
-                .setTimeAtLastEncounter(toIndividualTimeAtLastEncounter(v1Indvidual))
-                // no vital status or gender
-                .build();
+    public static Optional<Individual> toIndividual(org.phenopackets.schema.v1.core.Individual v1Individual) {
+        if (v1Individual.equals(org.phenopackets.schema.v1.core.Individual.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
+        Individual.Builder builder = Individual.newBuilder();
+
+        String id = v1Individual.getId();
+        if (!id.isEmpty()) {
+            isDefault = false;
+            builder.setId(id);
+        }
+
+        if (v1Individual.getAlternateIdsCount() != 0) {
+            isDefault = false;
+            builder.addAllAlternateIds(v1Individual.getAlternateIdsList());
+        }
+
+        Timestamp dateOfBirth = v1Individual.getDateOfBirth();
+        if (!dateOfBirth.equals(Timestamp.getDefaultInstance())) {
+            isDefault = false;
+            builder.setDateOfBirth(dateOfBirth);
+        }
+
+        Sex sex = toSex(v1Individual.getSex());
+        if (!sex.equals(Sex.UNKNOWN_SEX) && !sex.equals(Sex.UNRECOGNIZED)) {
+            isDefault = false;
+            builder.setSex(sex);
+        }
+
+        KaryotypicSex karyotypicSex = toKaryotypicSex(v1Individual.getKaryotypicSex());
+        if (!karyotypicSex.equals(KaryotypicSex.UNKNOWN_KARYOTYPE) && !karyotypicSex.equals(KaryotypicSex.UNRECOGNIZED)) {
+            isDefault = false;
+            builder.setKaryotypicSex(karyotypicSex);
+        }
+
+        Optional<OntologyClass> taxonomy = toOntologyClass(v1Individual.getTaxonomy());
+        if (taxonomy.isPresent()) {
+            isDefault = false;
+            builder.setTaxonomy(taxonomy.get());
+        }
+
+        Optional<TimeElement> lastEncounter = toIndividualTimeAtLastEncounter(v1Individual);
+        if (lastEncounter.isPresent()) {
+            isDefault = false;
+            builder.setTimeAtLastEncounter(lastEncounter.get());
+        }
+
+        if (isDefault)
+            return Optional.empty();
+        else
+            // no vital status or gender
+            return Optional.of(builder.build());
     }
 
-    public static KaryotypicSex toKaryotypicSex(org.phenopackets.schema.v1.core.KaryotypicSex karyotypicSex) {
+    private static KaryotypicSex toKaryotypicSex(org.phenopackets.schema.v1.core.KaryotypicSex karyotypicSex) {
         return switch (karyotypicSex) {
             case XX -> KaryotypicSex.XX;
             case XY -> KaryotypicSex.XY;
@@ -44,7 +86,7 @@ public class IndividualConverter {
         };
     }
 
-    public static Sex toSex(org.phenopackets.schema.v1.core.Sex sex) {
+    static Sex toSex(org.phenopackets.schema.v1.core.Sex sex) {
         return switch (sex) {
             case FEMALE -> Sex.FEMALE;
             case MALE -> Sex.MALE;
@@ -54,12 +96,18 @@ public class IndividualConverter {
         };
     }
 
-    public static TimeElement toIndividualTimeAtLastEncounter(org.phenopackets.schema.v1.core.Individual v1Individual) {
+    private static Optional<TimeElement> toIndividualTimeAtLastEncounter(org.phenopackets.schema.v1.core.Individual v1Individual) {
         if (v1Individual.hasAgeAtCollection()) {
-            return TimeElement.newBuilder().setAge(toAge(v1Individual.getAgeAtCollection())).build();
-        } else if (v1Individual.hasAgeRangeAtCollection()) {
-            return TimeElement.newBuilder().setAgeRange(toAgeRange(v1Individual.getAgeRangeAtCollection())).build();
-        }
-        return TimeElement.getDefaultInstance();
+            return toAge(v1Individual.getAgeAtCollection())
+                    .map(age -> TimeElement.newBuilder()
+                            .setAge(age)
+                            .build());
+        } else if (v1Individual.hasAgeRangeAtCollection())
+           return toAgeRange(v1Individual.getAgeRangeAtCollection())
+                    .map(ageRange -> TimeElement.newBuilder()
+                            .setAgeRange(ageRange)
+                            .build());
+        else
+            return Optional.empty();
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/MetaDataConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/MetaDataConverter.java
@@ -23,29 +23,48 @@ public class MetaDataConverter {
         if (metaData.equals(org.phenopackets.schema.v1.core.MetaData.getDefaultInstance()))
             return Optional.empty();
 
-        List<ExternalReference> externalReferences = toExternalReferences(metaData.getExternalReferencesList());
-        List<Resource> resources = toResources(metaData.getResourcesList());
-        List<Update> updates = toUpdates(metaData.getUpdatesList());
+        boolean isDefault = true;
+        MetaData.Builder builder = MetaData.newBuilder().setPhenopacketSchemaVersion(VERSION);
 
-        if (metaData.getPhenopacketSchemaVersion().isEmpty()
-                && metaData.getCreated().equals(Timestamp.getDefaultInstance())
-                && metaData.getCreatedBy().isEmpty()
-                && metaData.getSubmittedBy().isEmpty()
-                && externalReferences.isEmpty()
-                && resources.isEmpty()
-                && updates.isEmpty()) {
-            return Optional.empty();
-        } else {
-            return Optional.of(MetaData.newBuilder()
-                    .setPhenopacketSchemaVersion(VERSION)
-                    .setCreated(metaData.getCreated())
-                    .setCreatedBy(metaData.getCreatedBy())
-                    .setSubmittedBy(metaData.getSubmittedBy())
-                    .addAllExternalReferences(externalReferences)
-                    .addAllResources(resources)
-                    .addAllUpdates(updates)
-                    .build());
+        Timestamp created = metaData.getCreated();
+        if (!created.equals(Timestamp.getDefaultInstance())) {
+            isDefault = false;
+            builder.setCreated(created);
         }
+
+        String createdBy = metaData.getCreatedBy();
+        if (!createdBy.isEmpty()) {
+            isDefault = false;
+            builder.setCreatedBy(createdBy);
+        }
+
+        String submittedBy = metaData.getSubmittedBy();
+        if (!submittedBy.isEmpty()) {
+            isDefault = false;
+            builder.setSubmittedBy(submittedBy);
+        }
+
+        List<Resource> resources = toResources(metaData.getResourcesList());
+        if (!resources.isEmpty()) {
+            isDefault = false;
+            builder.addAllResources(resources);
+        }
+
+        List<Update> updates = toUpdates(metaData.getUpdatesList());
+        if (!updates.isEmpty()) {
+            isDefault = false;
+            builder.addAllUpdates(updates);
+        }
+
+        List<ExternalReference> externalReferences = toExternalReferences(metaData.getExternalReferencesList());
+        if (!externalReferences.isEmpty()) {
+            isDefault = false;
+            builder.addAllExternalReferences(externalReferences);
+        }
+
+        return isDefault
+                ? Optional.empty()
+                : Optional.of(builder.build());
     }
 
     private static List<Update> toUpdates(List<org.phenopackets.schema.v1.core.Update> updatesList) {

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/MetaDataConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/MetaDataConverter.java
@@ -1,9 +1,13 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
+import com.google.protobuf.Timestamp;
+import org.phenopackets.schema.v2.core.ExternalReference;
 import org.phenopackets.schema.v2.core.MetaData;
+import org.phenopackets.schema.v2.core.Resource;
 import org.phenopackets.schema.v2.core.Update;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.ExternalReferenceConverter.toExternalReferences;
 import static org.phenopackets.phenopackettools.converter.converters.v2.ResourceConverter.toResources;
@@ -15,27 +19,55 @@ public class MetaDataConverter {
     private MetaDataConverter() {
     }
 
-    public static MetaData toMetaData(org.phenopackets.schema.v1.core.MetaData metaData) {
-        return MetaData.newBuilder()
-                .setPhenopacketSchemaVersion(VERSION)
-                .setCreated(metaData.getCreated())
-                .setCreatedBy(metaData.getCreatedBy())
-                .setSubmittedBy(metaData.getSubmittedBy())
-                .addAllExternalReferences(toExternalReferences(metaData.getExternalReferencesList()))
-                .addAllResources(toResources(metaData.getResourcesList()))
-                .addAllUpdates(toUpdates(metaData.getUpdatesList()))
-                .build();
+    public static Optional<MetaData> toMetaData(org.phenopackets.schema.v1.core.MetaData metaData) {
+        if (metaData.equals(org.phenopackets.schema.v1.core.MetaData.getDefaultInstance()))
+            return Optional.empty();
+
+        List<ExternalReference> externalReferences = toExternalReferences(metaData.getExternalReferencesList());
+        List<Resource> resources = toResources(metaData.getResourcesList());
+        List<Update> updates = toUpdates(metaData.getUpdatesList());
+
+        if (metaData.getPhenopacketSchemaVersion().isEmpty()
+                && metaData.getCreated().equals(Timestamp.getDefaultInstance())
+                && metaData.getCreatedBy().isEmpty()
+                && metaData.getSubmittedBy().isEmpty()
+                && externalReferences.isEmpty()
+                && resources.isEmpty()
+                && updates.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(MetaData.newBuilder()
+                    .setPhenopacketSchemaVersion(VERSION)
+                    .setCreated(metaData.getCreated())
+                    .setCreatedBy(metaData.getCreatedBy())
+                    .setSubmittedBy(metaData.getSubmittedBy())
+                    .addAllExternalReferences(externalReferences)
+                    .addAllResources(resources)
+                    .addAllUpdates(updates)
+                    .build());
+        }
     }
 
     private static List<Update> toUpdates(List<org.phenopackets.schema.v1.core.Update> updatesList) {
-        return updatesList.stream().map(MetaDataConverter::toUpdate).toList();
+        return updatesList.stream()
+                .map(MetaDataConverter::toUpdate)
+                .flatMap(Optional::stream)
+                .toList();
     }
 
-    private static Update toUpdate(org.phenopackets.schema.v1.core.Update update) {
-        return Update.newBuilder()
+    private static Optional<Update> toUpdate(org.phenopackets.schema.v1.core.Update update) {
+        if (update.equals(org.phenopackets.schema.v1.core.Update.getDefaultInstance()))
+            return Optional.empty();
+
+        if (update.getUpdatedBy().isEmpty()
+                && update.getTimestamp().equals(Timestamp.getDefaultInstance())
+                && update.getComment().isEmpty())
+            return Optional.empty();
+        else
+            return Optional.of(Update.newBuilder()
                 .setUpdatedBy(update.getUpdatedBy())
                 .setTimestamp(update.getTimestamp())
                 .setComment(update.getComment())
-                .build();
+                .build());
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/OntologyClassConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/OntologyClassConverter.java
@@ -3,24 +3,27 @@ package org.phenopackets.phenopackettools.converter.converters.v2;
 import org.phenopackets.schema.v2.core.OntologyClass;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
-public class OntologyClassConverter {
+class OntologyClassConverter {
 
     private OntologyClassConverter() {
     }
 
-    public static List<OntologyClass> toOntologyClassList(List<org.phenopackets.schema.v1.core.OntologyClass> ontologyClasses) {
-        return ontologyClasses.stream().map(OntologyClassConverter::toOntologyClass).collect(Collectors.toUnmodifiableList());
+    static List<OntologyClass> toOntologyClassList(List<org.phenopackets.schema.v1.core.OntologyClass> ontologyClasses) {
+        // Returns non-default ontology classes.
+        return ontologyClasses.stream()
+                .map(OntologyClassConverter::toOntologyClass)
+                .flatMap(Optional::stream)
+                .toList();
     }
 
-    public static OntologyClass toOntologyClass(org.phenopackets.schema.v1.core.OntologyClass v1OntologyClass) {
-        if (org.phenopackets.schema.v1.core.OntologyClass.getDefaultInstance().equals(v1OntologyClass)) {
-            return OntologyClass.getDefaultInstance();
-        }
-        return OntologyClass.newBuilder()
+    static Optional<OntologyClass> toOntologyClass(org.phenopackets.schema.v1.core.OntologyClass v1OntologyClass) {
+        if (v1OntologyClass.equals(org.phenopackets.schema.v1.core.OntologyClass.getDefaultInstance()))
+            return Optional.empty();
+        return Optional.of(OntologyClass.newBuilder()
                 .setId(v1OntologyClass.getId())
                 .setLabel(v1OntologyClass.getLabel())
-                .build();
+                .build());
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PedigreeConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PedigreeConverter.java
@@ -1,9 +1,10 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
 import org.phenopackets.schema.v2.core.Pedigree;
+import org.phenopackets.schema.v2.core.Sex;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.IndividualConverter.toSex;
 
@@ -12,38 +13,75 @@ public class PedigreeConverter {
     private PedigreeConverter() {
     }
 
-    public static Pedigree toPedigree(org.phenopackets.schema.v1.core.Pedigree v1Pedigree) {
+    public static Optional<Pedigree> toPedigree(org.phenopackets.schema.v1.core.Pedigree v1Pedigree) {
+        if (v1Pedigree.equals(org.phenopackets.schema.v1.core.Pedigree.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
         Pedigree.Builder builder = Pedigree.newBuilder();
 
-         if (v1Pedigree.getPersonsCount() > 0) {
-            builder.addAllPersons(toPersons(v1Pedigree.getPersonsList()));
+        List<Pedigree.Person> persons = toPersons(v1Pedigree.getPersonsList());
+        if (!persons.isEmpty()) {
+            isDefault = false;
+            builder.addAllPersons(persons);
          }
 
-        return builder.build();
+        if (isDefault)
+            return Optional.empty();
+        else
+            return Optional.of(builder.build());
     }
 
     private static List<Pedigree.Person> toPersons(List<org.phenopackets.schema.v1.core.Pedigree.Person> v1PersonsList) {
-        return v1PersonsList.stream().map(PedigreeConverter::toPerson).collect(Collectors.toUnmodifiableList());
+        return v1PersonsList.stream()
+                .map(PedigreeConverter::toPerson)
+                .flatMap(Optional::stream)
+                .toList();
     }
 
-    private static Pedigree.Person toPerson(org.phenopackets.schema.v1.core.Pedigree.Person v1Person) {
+    private static Optional<Pedigree.Person> toPerson(org.phenopackets.schema.v1.core.Pedigree.Person v1Person) {
+        if (v1Person.equals(org.phenopackets.schema.v1.core.Pedigree.Person.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
         Pedigree.Person.Builder builder = Pedigree.Person.newBuilder();
 
-        builder.setIndividualId(v1Person.getIndividualId());
-        builder.setSex(toSex(v1Person.getSex()));
-        builder.setAffectedStatus(toAffectedStatus(v1Person.getAffectedStatus()));
+        String individualId = v1Person.getIndividualId();
+        if (!individualId.isEmpty()) {
+            isDefault = false;
+            builder.setIndividualId(individualId);
+        }
+
+        Sex sex = toSex(v1Person.getSex());
+        if (!sex.equals(Sex.UNRECOGNIZED) && !sex.equals(Sex.UNKNOWN_SEX)) {
+            isDefault = false;
+            builder.setSex(sex);
+        }
+
+        Pedigree.Person.AffectedStatus affectedStatus = toAffectedStatus(v1Person.getAffectedStatus());
+        if (!affectedStatus.equals(Pedigree.Person.AffectedStatus.UNRECOGNIZED) && !affectedStatus.equals(Pedigree.Person.AffectedStatus.MISSING)) {
+            isDefault = false;
+            builder.setAffectedStatus(affectedStatus);
+        }
 
         if (!v1Person.getFamilyId().isEmpty()) {
+            isDefault = false;
             builder.setFamilyId(v1Person.getFamilyId());
         }
         if (!v1Person.getMaternalId().isEmpty()) {
+            isDefault = false;
             builder.setMaternalId(v1Person.getMaternalId());
         }
+
         if (!v1Person.getPaternalId().isEmpty()) {
+            isDefault = false;
             builder.setPaternalId(v1Person.getPaternalId());
         }
 
-        return builder.build();
+        if (isDefault)
+            return Optional.empty();
+        else
+            return Optional.of(builder.build());
     }
 
     private static Pedigree.Person.AffectedStatus toAffectedStatus(org.phenopackets.schema.v1.core.Pedigree.Person.AffectedStatus v1AffectedStatus) {

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PhenotypicFeatureConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PhenotypicFeatureConverter.java
@@ -3,6 +3,7 @@ package org.phenopackets.phenopackettools.converter.converters.v2;
 import org.phenopackets.schema.v2.core.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAge;
 import static org.phenopackets.phenopackettools.converter.converters.v2.AgeConverter.toAgeRange;
@@ -18,45 +19,93 @@ public class PhenotypicFeatureConverter {
     public static List<PhenotypicFeature> toPhenotypicFeatures(List<org.phenopackets.schema.v1.core.PhenotypicFeature> v1PhenotypicFeaturesList) {
         return v1PhenotypicFeaturesList.stream()
                 .map(PhenotypicFeatureConverter::toPhenotypicFeature)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    public static PhenotypicFeature toPhenotypicFeature(org.phenopackets.schema.v1.core.PhenotypicFeature v1PhenotypicFeature) {
+    static Optional<PhenotypicFeature> toPhenotypicFeature(org.phenopackets.schema.v1.core.PhenotypicFeature v1PhenotypicFeature) {
+        boolean isDefault = true;
+
         PhenotypicFeature.Builder builder = PhenotypicFeature.newBuilder();
-        builder.setType(toOntologyClass(v1PhenotypicFeature.getType()));
-        builder.setExcluded(v1PhenotypicFeature.getNegated());
-        if (v1PhenotypicFeature.hasSeverity()) {
-            builder.setSeverity(toOntologyClass(v1PhenotypicFeature.getSeverity()));
+
+        Optional<OntologyClass> type = toOntologyClass(v1PhenotypicFeature.getType());
+        if (type.isPresent()) {
+            isDefault = false;
+            builder.setType(type.get());
         }
+
+        if (v1PhenotypicFeature.getNegated()) {
+            isDefault = false;
+            builder.setExcluded(true);
+        }
+
+        Optional<OntologyClass> severity = toOntologyClass(v1PhenotypicFeature.getSeverity());
+        if (v1PhenotypicFeature.hasSeverity() && severity.isPresent()) {
+            isDefault = false;
+            builder.setSeverity(severity.get());
+        }
+
         if (v1PhenotypicFeature.getModifiersCount() > 0) {
-            builder.addAllModifiers(toModifiers(v1PhenotypicFeature.getModifiersList()));
+            List<OntologyClass> modifiers = toOntologyClassList(v1PhenotypicFeature.getModifiersList());
+            if (!modifiers.isEmpty()) {
+                isDefault = false;
+                builder.addAllModifiers(modifiers);
+            }
         }
+
         if (v1PhenotypicFeature.getEvidenceCount() > 0) {
-            builder.addAllEvidence(toEvidences(v1PhenotypicFeature.getEvidenceList()));
+            List<Evidence> evidences = toEvidences(v1PhenotypicFeature.getEvidenceList());
+            if (!evidences.isEmpty()) {
+                isDefault = false;
+                builder.addAllEvidence(evidences);
+            }
         }
-        if (v1PhenotypicFeature.hasAgeOfOnset() ||
-                v1PhenotypicFeature.hasAgeRangeOfOnset() ||
-                v1PhenotypicFeature.hasClassOfOnset()) {
-            builder.setOnset(toPhenotypicFeatureOnset(v1PhenotypicFeature));
+
+        Optional<TimeElement> onset = toPhenotypicFeatureOnset(v1PhenotypicFeature);
+        if (onset.isPresent()) {
+            isDefault = false;
+            builder.setOnset(onset.get());
         }
+
         if (!v1PhenotypicFeature.getDescription().isEmpty()) {
+            isDefault = false;
             builder.setDescription(v1PhenotypicFeature.getDescription());
         }
-        return builder.build();
+
+        return isDefault
+                ? Optional.empty()
+                : Optional.of(builder.build());
     }
 
-    public static TimeElement toPhenotypicFeatureOnset(org.phenopackets.schema.v1.core.PhenotypicFeature v1PhenotypicFeature) {
+    private static Optional<TimeElement> toPhenotypicFeatureOnset(org.phenopackets.schema.v1.core.PhenotypicFeature v1PhenotypicFeature) {
+        if (v1PhenotypicFeature.equals(TimeElement.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
+        TimeElement.Builder builder = TimeElement.newBuilder();
         if (v1PhenotypicFeature.hasClassOfOnset()) {
-            return TimeElement.newBuilder().setOntologyClass(toOntologyClass(v1PhenotypicFeature.getClassOfOnset())).build();
+            Optional<OntologyClass> onsetClass = toOntologyClass(v1PhenotypicFeature.getClassOfOnset());
+            if (onsetClass.isPresent()) {
+                isDefault = false;
+                builder.setOntologyClass(onsetClass.get());
+            }
         } else if (v1PhenotypicFeature.hasAgeOfOnset()) {
-            return TimeElement.newBuilder().setAge(toAge(v1PhenotypicFeature.getAgeOfOnset())).build();
+            Optional<Age> age = toAge(v1PhenotypicFeature.getAgeOfOnset());
+            if (age.isPresent()) {
+                isDefault = false;
+                builder.setAge(age.get());
+            }
         } else if (v1PhenotypicFeature.hasAgeRangeOfOnset()) {
-            return TimeElement.newBuilder().setAgeRange(toAgeRange(v1PhenotypicFeature.getAgeRangeOfOnset())).build();
+            Optional<AgeRange> ageRange = toAgeRange(v1PhenotypicFeature.getAgeRangeOfOnset());
+            if (ageRange.isPresent()) {
+                isDefault = false;
+                builder.setAgeRange(ageRange.get());
+            }
         }
-        return TimeElement.getDefaultInstance();
+
+        return isDefault
+                ? Optional.empty()
+                : Optional.of(builder.build());
     }
 
-    public static List<OntologyClass> toModifiers(List<org.phenopackets.schema.v1.core.OntologyClass> modifiersList) {
-        return toOntologyClassList(modifiersList);
-    }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ProcedureConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ProcedureConverter.java
@@ -1,25 +1,40 @@
 package org.phenopackets.phenopackettools.converter.converters.v2;
 
+import org.phenopackets.schema.v2.core.OntologyClass;
 import org.phenopackets.schema.v2.core.Procedure;
+
+import java.util.Optional;
 
 import static org.phenopackets.phenopackettools.converter.converters.v2.OntologyClassConverter.toOntologyClass;
 
-public class ProcedureConverter {
+class ProcedureConverter {
 
     private ProcedureConverter() {
     }
 
-    public static Procedure toProcedure(org.phenopackets.schema.v1.core.Procedure procedure) {
-        if (org.phenopackets.schema.v1.core.Procedure.getDefaultInstance().equals(procedure)) {
-            return Procedure.getDefaultInstance();
+    static Optional<Procedure> toProcedure(org.phenopackets.schema.v1.core.Procedure procedure) {
+        if (procedure.equals(org.phenopackets.schema.v1.core.Procedure.getDefaultInstance()))
+            return Optional.empty();
+
+        boolean isDefault = true;
+        Procedure.Builder builder = Procedure.newBuilder();
+
+        Optional<OntologyClass> code = toOntologyClass(procedure.getCode());
+        if (code.isPresent()) {
+            isDefault = false;
+            builder.setCode(code.get());
         }
 
-        Procedure.Builder builder = Procedure.newBuilder();
-        if (procedure.hasBodySite()) {
-            builder.setBodySite(toOntologyClass(procedure.getBodySite()));
+        Optional<OntologyClass> bodySite = toOntologyClass(procedure.getBodySite());
+        if (bodySite.isPresent()) {
+            isDefault = false;
+            builder.setBodySite(bodySite.get());
         }
-        return builder
-                .setCode(toOntologyClass(procedure.getCode()))
-                .build();
+
+        if (isDefault)
+            return Optional.empty();
+        else
+            return Optional.of(builder.build());
+
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ResourceConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/ResourceConverter.java
@@ -3,26 +3,39 @@ package org.phenopackets.phenopackettools.converter.converters.v2;
 import org.phenopackets.schema.v2.core.Resource;
 
 import java.util.List;
+import java.util.Optional;
 
-public class ResourceConverter {
+class ResourceConverter {
 
     private ResourceConverter() {
     }
 
-    public static List<Resource> toResources(List<org.phenopackets.schema.v1.core.Resource> resourcesList) {
+    static List<Resource> toResources(List<org.phenopackets.schema.v1.core.Resource> resourcesList) {
         return resourcesList.stream()
                 .map(ResourceConverter::toResource)
+                .flatMap(Optional::stream)
                 .toList();
     }
 
-    public static Resource toResource(org.phenopackets.schema.v1.core.Resource resource) {
-        return Resource.newBuilder()
-                .setId(resource.getId())
-                .setName(resource.getName())
-                .setVersion(resource.getVersion())
-                .setUrl(resource.getUrl())
-                .setIriPrefix(resource.getIriPrefix())
-                .setNamespacePrefix(resource.getNamespacePrefix())
-                .build();
+    static Optional<Resource> toResource(org.phenopackets.schema.v1.core.Resource resource) {
+        if (resource.equals(org.phenopackets.schema.v1.core.Resource.getDefaultInstance()))
+            return Optional.empty();
+
+        if (resource.getId().isEmpty()
+                && resource.getName().isEmpty()
+                && resource.getVersion().isEmpty()
+                && resource.getUrl().isEmpty()
+                && resource.getIriPrefix().isEmpty()
+                && resource.getName().isEmpty()) {
+            return Optional.empty();
+        } else
+            return Optional.of(Resource.newBuilder()
+                    .setId(resource.getId())
+                    .setName(resource.getName())
+                    .setVersion(resource.getVersion())
+                    .setUrl(resource.getUrl())
+                    .setIriPrefix(resource.getIriPrefix())
+                    .setNamespacePrefix(resource.getNamespacePrefix())
+                    .build());
     }
 }

--- a/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverterTest.java
+++ b/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverterTest.java
@@ -1,0 +1,62 @@
+package org.phenopackets.phenopackettools.converter.converters.v2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.phenopackets.schema.v1.core.Age;
+import org.phenopackets.schema.v1.core.AgeRange;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class AgeConverterTest {
+
+    @Test
+    public void convertNonDefaultAge() {
+        Age v1 = Age.newBuilder().setAge("P1Y").build();
+        Optional<org.phenopackets.schema.v2.core.Age> result = AgeConverter.toAge(v1);
+        assertThat(result.isPresent(), equalTo(true));
+
+        org.phenopackets.schema.v2.core.Age v2 = result.get();
+        assertThat(v2.getIso8601Duration(), equalTo(v1.getAge()));
+    }
+
+    @Test
+    public void convertDefaultAge() {
+        Age v1 = Age.newBuilder().build();
+        Optional<org.phenopackets.schema.v2.core.Age> result = AgeConverter.toAge(v1);
+        assertThat(result.isPresent(), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "P1Y,  P2Y",
+            " '',  P2Y",
+            "P1Y,  ''",
+    })
+    public void convertNonDefaultAgeRange(String start, String end) {
+        AgeRange v1 = AgeRange.newBuilder()
+                .setStart(Age.newBuilder().setAge(start).build())
+                .setEnd(Age.newBuilder().setAge(end).build())
+                .build();
+
+        Optional<org.phenopackets.schema.v2.core.AgeRange> result = AgeConverter.toAgeRange(v1);
+        assertThat(result.isPresent(), equalTo(true));
+
+        org.phenopackets.schema.v2.core.AgeRange v2 = result.get();
+
+        assertThat(v2, not(sameInstance(org.phenopackets.schema.v2.core.AgeRange.getDefaultInstance())));
+        assertThat(v2.getStart().getIso8601Duration(), equalTo(start));
+        assertThat(v2.getEnd().getIso8601Duration(), equalTo(end));
+    }
+
+    @Test
+    public void convertDefaultAgeRange() {
+        AgeRange v1 = AgeRange.newBuilder().build();
+
+        Optional<org.phenopackets.schema.v2.core.AgeRange> result = AgeConverter.toAgeRange(v1);
+        assertThat(result.isPresent(), equalTo(false));
+    }
+}

--- a/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/v2/IndividualConverterTest.java
+++ b/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/v2/IndividualConverterTest.java
@@ -1,0 +1,35 @@
+package org.phenopackets.phenopackettools.converter.converters.v2;
+
+import org.junit.jupiter.api.Test;
+import org.phenopackets.phenopackettools.test.TestData;
+import org.phenopackets.schema.v1.core.Individual;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class IndividualConverterTest {
+
+    @Test
+    public void convertNonDefaultIndividual() {
+        Individual v1 = TestData.V1.comprehensivePhenopacket().getSubject();
+
+        Optional<org.phenopackets.schema.v2.core.Individual> result = IndividualConverter.toIndividual(v1);
+        assertThat(result.isPresent(), equalTo(true));
+
+        org.phenopackets.schema.v2.core.Individual v2 = result.get();
+        assertThat(v2.getId(), equalTo("14 year-old boy"));
+
+    }
+
+    @Test
+    public void convertDefaultIndividual() {
+        Individual v1 = Individual.newBuilder().build();
+
+        Optional<org.phenopackets.schema.v2.core.Individual> result = IndividualConverter.toIndividual(v1);
+        assertThat(result.isEmpty(), equalTo(true));
+
+    }
+}

--- a/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/print/PhenopacketPrintUtil.java
+++ b/phenopacket-tools-util/src/main/java/org/phenopackets/phenopackettools/util/print/PhenopacketPrintUtil.java
@@ -23,7 +23,8 @@ public class PhenopacketPrintUtil {
     private static final JsonFormat.Parser PARSER = JsonFormat.parser();
 
     private static final JsonFormat.Printer PRINTER = JsonFormat.printer()
-            .includingDefaultValueFields(defaultValueFields());
+            .includingDefaultValueFields(defaultValueFields())
+            ;
 
     private static Set<Descriptors.FieldDescriptor> defaultValueFields() {
         /*


### PR DESCRIPTION
Do not convert default values from the v1 phenopacket elements. Return the default instance if there is nothing to convert.