### PR TITLE
Include VCF info field in v1 -> v2 conversion, improve handling of VCF filter fields in phenopacket builder

### DIFF
--- a/phenopacket-tools-builder/src/main/java/org/phenopackets/phenopackettools/builder/builders/VariationDescriptorBuilder.java
+++ b/phenopacket-tools-builder/src/main/java/org/phenopackets/phenopackettools/builder/builders/VariationDescriptorBuilder.java
@@ -100,6 +100,10 @@ public class VariationDescriptorBuilder {
         return this;
     }
 
+    public VariationDescriptorBuilder moleculeContext(MoleculeContext context) {
+        builder.setMoleculeContext(context);
+        return this;
+    }
 
     public VariationDescriptorBuilder structuralType(OntologyClass structuralType) {
         builder.setStructuralType(structuralType);

--- a/phenopacket-tools-builder/src/test/java/org/phenopackets/phenopackettools/builder/builders/VcfRecordBuilderTest.java
+++ b/phenopacket-tools-builder/src/test/java/org/phenopackets/phenopackettools/builder/builders/VcfRecordBuilderTest.java
@@ -1,0 +1,30 @@
+package org.phenopackets.phenopackettools.builder.builders;
+
+import org.ga4gh.vrsatile.v1.VcfRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class VcfRecordBuilderTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "PASS,      PASS",
+            "pass,      PASS",
+            "q50,       q50",
+            "q50;q10,   q50;q10",
+            "q50;pass,  PASS",
+            "pass;q50,  q50",
+    })
+    public void addFilter(String filter, String expected) {
+        VcfRecord record = VcfRecordBuilder.builder("GRCh37", "chr1", 123_456, "C", "G")
+                .filter(filter)
+                .build();
+
+        assertThat(record.getFilter(), equalTo(expected));
+    }
+}

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2ConverterImpl.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2ConverterImpl.java
@@ -234,6 +234,7 @@ class V1ToV2ConverterImpl implements V1ToV2Converter {
                                     vcfAllele.getChr(), vcfAllele.getPos(),
                                     vcfAllele.getRef(),
                                     vcfAllele.getAlt())
+                            .info(vcfAllele.getInfo())
                             .build();
                     yield VariationDescriptorBuilder.builder(vcfAllele.getId())
                             .vcfRecord(vcfRecord)

--- a/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2ConverterTest.java
+++ b/phenopacket-tools-converter/src/test/java/org/phenopackets/phenopackettools/converter/converters/V1ToV2ConverterTest.java
@@ -1,6 +1,7 @@
 package org.phenopackets.phenopackettools.converter.converters;
 
 import org.ga4gh.vrsatile.v1.Expression;
+import org.ga4gh.vrsatile.v1.MoleculeContext;
 import org.ga4gh.vrsatile.v1.VariationDescriptor;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -101,6 +102,7 @@ public class V1ToV2ConverterTest {
                                 .setSyntax("hgvs")
                                 .setValue("NM_001848.2:c.877G>A")
                                 .build())
+                        .setMoleculeContext(MoleculeContext.transcript)
                         .setAllelicState(OntologyClass.newBuilder()
                                 .setId("GENO:0000135")
                                 .setLabel("heterozygous")


### PR DESCRIPTION
The PR fixes #184 and improves handling of the filter field when building a `VcfRecord`. The builder ensures that the final `VcfRecord` is not logically inconsistent and the filter field has one of the three following states:
- *empty* - no filtering info
- *pass* - `filter==PASS`
- *filtered* - any sequence of `;`-separated filter values