### PR TITLE
Unset field from v1 should not be set to a default instance in v2 during conversion

### DIFF
--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/AgeConverter.java
@@ -29,12 +29,11 @@ class AgeConverter {
 
         if (start.isEmpty() && end.isEmpty())
             return Optional.empty();
-        else
-            return Optional.of(
-                    AgeRange.newBuilder()
-                            .setStart(start.orElse(Age.getDefaultInstance()))
-                            .setEnd(end.orElse(Age.getDefaultInstance()))
-                            .build()
-            );
+        else {
+            AgeRange.Builder builder = AgeRange.newBuilder();
+            start.ifPresent(builder::setStart);
+            end.ifPresent(builder::setEnd);
+            return Optional.of(builder.build());
+        }
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/EvidenceConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/EvidenceConverter.java
@@ -22,7 +22,7 @@ class EvidenceConverter {
                 .toList();
     }
 
-    static Optional<Evidence> toEvidence(org.phenopackets.schema.v1.core.Evidence v1Evidence) {
+    private static Optional<Evidence> toEvidence(org.phenopackets.schema.v1.core.Evidence v1Evidence) {
         if (v1Evidence.equals(org.phenopackets.schema.v1.core.Evidence.getDefaultInstance()))
             return Optional.empty();
 
@@ -32,9 +32,9 @@ class EvidenceConverter {
         if (evidenceCode.isEmpty() && externalReference.isEmpty())
             return Optional.empty();
 
-        return Optional.of(Evidence.newBuilder()
-                .setEvidenceCode(evidenceCode.orElse(OntologyClass.getDefaultInstance()))
-                .setReference(externalReference.orElse(ExternalReference.getDefaultInstance()))
-                .build());
+        Evidence.Builder builder = Evidence.newBuilder();
+        evidenceCode.ifPresent(builder::setEvidenceCode);
+        externalReference.ifPresent(builder::setReference);
+        return Optional.of(builder.build());
     }
 }

--- a/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PhenotypicFeatureConverter.java
+++ b/phenopacket-tools-converter/src/main/java/org/phenopackets/phenopackettools/converter/converters/v2/PhenotypicFeatureConverter.java
@@ -78,7 +78,7 @@ public class PhenotypicFeatureConverter {
     }
 
     private static Optional<TimeElement> toPhenotypicFeatureOnset(org.phenopackets.schema.v1.core.PhenotypicFeature v1PhenotypicFeature) {
-        if (v1PhenotypicFeature.equals(TimeElement.getDefaultInstance()))
+        if (v1PhenotypicFeature.equals(org.phenopackets.schema.v1.core.PhenotypicFeature.getDefaultInstance()))
             return Optional.empty();
 
         boolean isDefault = true;


### PR DESCRIPTION
The PR fixes sub-optimal behavior of parts of the v1 -> v2 conversion, where a v2 field is set to a default instance if the field is missing in v1.