### PR TITLE
Enable JSON serialization for validation results

### DIFF
--- a/phenopacket-tools-validator-core/pom.xml
+++ b/phenopacket-tools-validator-core/pom.xml
@@ -37,6 +37,11 @@
             <groupId>org.monarchinitiative.phenol</groupId>
             <artifactId>phenol-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.monarchinitiative.phenol</groupId>

--- a/phenopacket-tools-validator-core/src/main/java/module-info.java
+++ b/phenopacket-tools-validator-core/src/main/java/module-info.java
@@ -14,6 +14,8 @@ module org.phenopackets.phenopackettools.validator.core {
     requires org.monarchinitiative.phenol.core;
     requires org.phenopackets.schema;
 
+    requires com.fasterxml.jackson.databind;
+
     // There are many places where the protobuf classes are part of the API, e.g. as type parameter
     // of PhenopacketFormatConverter.
     requires transitive com.google.protobuf;

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationResult.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationResult.java
@@ -1,8 +1,14 @@
 package org.phenopackets.phenopackettools.validator.core;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * {@code ValidationResult} contains results of a single validation step performed by a {@link PhenopacketValidator}.
  */
+@JsonSerialize(as = ValidationResult.class)
+@JsonPropertyOrder({"validatorInfo", "level", "category", "message"})
 public interface ValidationResult {
 
     /**
@@ -36,21 +42,25 @@ public interface ValidationResult {
     /**
      * @return information about the validator used to create the {@link ValidationResult}.
      */
+    @JsonGetter
     ValidatorInfo validatorInfo();
 
     /**
      * @return level of the validation
      */
+    @JsonGetter
     ValidationLevel level();
 
     /**
      * @return an error category.
      */
+    @JsonGetter
     String category();
 
     /**
      * @return specific error message
      */
+    @JsonGetter
     String message();
 
 }

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationResults.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidationResults.java
@@ -1,5 +1,10 @@
 package org.phenopackets.phenopackettools.validator.core;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +16,8 @@ import java.util.List;
  * The results contain info regarding which validators were run ({@link #validators()}) and the issues found during
  * the validation ({@link #validationResults()}).
  */
+@JsonSerialize(as = ValidationResults.class)
+@JsonPropertyOrder({"validators", "validationResults"})
 public interface ValidationResults {
 
     static ValidationResults of(List<ValidatorInfo> validators,
@@ -31,16 +38,19 @@ public interface ValidationResults {
     /**
      * @return a list of {@link ValidatorInfo} representing validators applied to the top-level element.
      */
+    @JsonGetter
     List<ValidatorInfo> validators();
 
     /**
      * @return a list of {@link ValidationResult} representing the issues found in the top-level element.
      */
+    @JsonGetter
     List<ValidationResult> validationResults();
 
     /**
      * @return {@code true} if no issues have been found and the validated item is valid.
      */
+    @JsonIgnore
     default boolean isValid() {
         return validationResults().isEmpty();
     }

--- a/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfo.java
+++ b/phenopacket-tools-validator-core/src/main/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfo.java
@@ -1,8 +1,14 @@
 package org.phenopackets.phenopackettools.validator.core;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * A description of a {@link PhenopacketValidator}.
  */
+@JsonSerialize(as = ValidatorInfo.class)
+@JsonPropertyOrder({"validatorId", "validatorName", "description"})
 public interface ValidatorInfo {
 
     static ValidatorInfo baseSyntaxValidation() {
@@ -25,16 +31,19 @@ public interface ValidatorInfo {
     /**
      * @return string with a unique validator ID.
      */
+    @JsonGetter
     String validatorId();
 
     /**
      * @return human-friendly validator name.
      */
+    @JsonGetter
     String validatorName();
 
     /**
      * @return brief description of the validation provided by the validator.
      */
+    @JsonGetter
     String description();
 
 }

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultTest.java
@@ -28,7 +28,7 @@ public class ValidationResultTest {
                           "level" : "ERROR",
                           "category" : "CATEGORY",
                           "message" : "MESSAGE"
-                        }""")
+                        }""".replaceAll("\n", System.lineSeparator()))
         );
     }
 }

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultTest.java
@@ -1,0 +1,34 @@
+package org.phenopackets.phenopackettools.validator.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class ValidationResultTest {
+
+    @Test
+    public void serialize() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        ValidatorInfo info = ValidatorInfo.of("ID", "NAME", "DESCRIPTION");
+        ValidationResult result = ValidationResult.of(info, ValidationLevel.ERROR, "CATEGORY", "MESSAGE");
+
+        assertThat(mapper.writeValueAsString(result),
+                equalTo("""
+                        {
+                          "validatorInfo" : {
+                            "validatorId" : "ID",
+                            "validatorName" : "NAME",
+                            "description" : "DESCRIPTION"
+                          },
+                          "level" : "ERROR",
+                          "category" : "CATEGORY",
+                          "message" : "MESSAGE"
+                        }""")
+        );
+    }
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultsTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultsTest.java
@@ -56,6 +56,6 @@ public class ValidationResultsTest {
                     "category" : "CATEGORY2",
                     "message" : "MESSAGE2"
                   } ]
-                }"""));
+                }""".replaceAll("\n", System.lineSeparator())));
     }
 }

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultsTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidationResultsTest.java
@@ -1,0 +1,61 @@
+package org.phenopackets.phenopackettools.validator.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class ValidationResultsTest {
+
+    @Test
+    public void serialize() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        List<ValidatorInfo> validatorInfos = List.of(
+                ValidatorInfo.of("ID1", "NAME1", "DESCRIPTION1"),
+                ValidatorInfo.of("ID2", "NAME2", "DESCRIPTION2")
+        );
+        List<ValidationResult> data = List.of(
+                ValidationResult.of(validatorInfos.get(0), ValidationLevel.ERROR, "CATEGORY1", "MESSAGE1"),
+                ValidationResult.of(validatorInfos.get(1), ValidationLevel.WARNING, "CATEGORY2", "MESSAGE2")
+        );
+        ValidationResults results = ValidationResults.of(validatorInfos, data);
+
+        assertThat(mapper.writeValueAsString(results), equalTo("""
+                {
+                  "validators" : [ {
+                    "validatorId" : "ID1",
+                    "validatorName" : "NAME1",
+                    "description" : "DESCRIPTION1"
+                  }, {
+                    "validatorId" : "ID2",
+                    "validatorName" : "NAME2",
+                    "description" : "DESCRIPTION2"
+                  } ],
+                  "validationResults" : [ {
+                    "validatorInfo" : {
+                      "validatorId" : "ID1",
+                      "validatorName" : "NAME1",
+                      "description" : "DESCRIPTION1"
+                    },
+                    "level" : "ERROR",
+                    "category" : "CATEGORY1",
+                    "message" : "MESSAGE1"
+                  }, {
+                    "validatorInfo" : {
+                      "validatorId" : "ID2",
+                      "validatorName" : "NAME2",
+                      "description" : "DESCRIPTION2"
+                    },
+                    "level" : "WARNING",
+                    "category" : "CATEGORY2",
+                    "message" : "MESSAGE2"
+                  } ]
+                }"""));
+    }
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfoTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfoTest.java
@@ -1,0 +1,27 @@
+package org.phenopackets.phenopackettools.validator.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ValidatorInfoTest {
+
+    @Test
+    public void serialize() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        ValidatorInfo info = ValidatorInfo.of("ID", "NAME", "DESCRIPTION");
+
+        assertThat(mapper.writeValueAsString(info), equalTo("""
+                {
+                  "validatorId" : "ID",
+                  "validatorName" : "NAME",
+                  "description" : "DESCRIPTION"
+                }""")
+        );
+    }
+}

--- a/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfoTest.java
+++ b/phenopacket-tools-validator-core/src/test/java/org/phenopackets/phenopackettools/validator/core/ValidatorInfoTest.java
@@ -21,7 +21,7 @@ public class ValidatorInfoTest {
                   "validatorId" : "ID",
                   "validatorName" : "NAME",
                   "description" : "DESCRIPTION"
-                }""")
+                }""".replaceAll("\n", System.lineSeparator()))
         );
     }
 }

--- a/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
+++ b/phenopacket-tools-validator-jsonschema/src/main/java/module-info.java
@@ -11,7 +11,8 @@
 module org.phenopackets.phenopackettools.validator.jsonschema {
     requires org.phenopackets.phenopackettools.util;
     requires transitive org.phenopackets.phenopackettools.validator.core;
-    requires org.phenopackets.schema;
+    // Transitive due to export of Phenopacket, Cohort, Family in JsonSchemaValidationWorkflowRunner.
+    requires transitive org.phenopackets.schema;
     requires com.fasterxml.jackson.databind;
     requires json.schema.validator;
     requires org.slf4j;


### PR DESCRIPTION
Enable JSON serialization for validation results. The Jackson serialization can serialize `ValidationResults` into JSON (or else) with no custom serializers.