### PR TITLE
Validate ISO8601 period strings

### DIFF
--- a/phenopacket-tools-validator-jsonschema/src/main/resources/org/phenopackets/phenopackettools/validator/jsonschema/v2/base.json
+++ b/phenopacket-tools-validator-jsonschema/src/main/resources/org/phenopackets/phenopackettools/validator/jsonschema/v2/base.json
@@ -94,7 +94,8 @@
       "properties": {
         "iso8601duration": {
           "description": "An ISO8601 string representing age.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d+[HMS])(\\d+H)?(\\d+M)?(\\d+S)?)?$"
         }
       },
       "required": ["iso8601duration"],


### PR DESCRIPTION
As pointed out in #192 , phenopacket-tools does not validate the ISO8601 period strings.

This PR adds the period string validation using a JSONSchema regexp.